### PR TITLE
put and clear page, max_results and next_marker in Blob::list, refactoring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,4 +43,4 @@ env:
     # override the default `--features unstable` used for the nightly branch (optional)
     - TRAVIS_CARGO_NIGHTLY_FEATURE=""
     # encrypted github token for doc upload (see `GH_TOKEN` link above)
-    - secure: "..."
+    - secure: "${GH_TOKEN}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change Log
 
+## [0.0.6](https://github.com/MindFlavor/AzureSDKForRust/releases/tag/0.0.6) (2016-01-12)
+
+**Implemented features:**
+* Added support for max_results in list_blobs. Now you can limit how many blobs could be returned by a single call.
+* Added support for next_marker in list_blobs. Now you can continue enumerating your blobs in subsequent calls.
+* Added put page for page blobs.
+* Added clear page for page blobs.
+
+**Refactoring:**
+* Added page constraints (512-bytes aligned).
+* Most methods moved from storage::Client to correct structs (ie storage::container::Container and storage::blob::Blob).
+* Moved list_blobs options in a separate structure (```azure::storage::blob::ListBlobOptions```).
+
 ## [0.0.5](https://github.com/MindFlavor/AzureSDKForRust/releases/tag/0.0.5) (2016-01-05)
 
 **Implemented features:**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "azure_sdk_for_rust"
-version = "0.0.4"
+version = "0.0.6"
 dependencies = [
  "RustyXML 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -35,7 +35,7 @@ name = "chrono"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -162,10 +162,10 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -229,7 +229,7 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "advapi32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -244,7 +244,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.3.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -272,7 +272,7 @@ name = "serde"
 version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -289,7 +289,7 @@ name = "tempdir"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -354,7 +354,7 @@ name = "uuid"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_sdk_for_rust"
-version = "0.0.5"
+version = "0.0.6"
 authors = ["Francesco Cogno <francesco.cogno@outlook.com>"]
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -16,31 +16,89 @@ Although I am a Microsoft employee, this is not a Microsoft endorsed project. It
 You can find examples in the test section (not yet existent as far as Azure is concerned) and in the main.rs file. Here is a sample however:
 
 ```rust
-use azure::storage::client;
-use azure::storage::container::PublicAccess;
+extern crate azure_sdk_for_rust;
+extern crate chrono;
+#[macro_use]
+extern crate mime;
+
+use azure::storage::{LeaseState, LeaseStatus};
+use azure::storage::client::Client;
+use azure::storage::blob::{Blob, BlobType};
+use azure::storage::container::{Container, PublicAccess};
+
+use chrono::UTC;
+
+use mime::Mime;
 
 fn main() {
-	let azure_storage_account = &"azure_storage_account";
-	let azure_storage_key= &"azure_storage_key";
+  let azure_storage_account = &"azure_storage_account";
+  let azure_storage_key= &"azure_storage_key";
 
-	// create the client struct. The third argument, if false, forces to use
-	// http instead of https. It's useful if you have trouble compiling
-	// hyper with openSSL activated.
-    let client = client::new(azure_storage_account, azure_storage_key, false);
+  // create the client struct. The third argument, if false, forces to use
+  // http instead of https. It's useful if you have trouble compiling
+  // hyper with openSSL activated.
+  let client = client::new(azure_storage_account, azure_storage_key, false);
 
-	// This call will create a new Azure Container called "wow"
-	// with public blob access (see https://msdn.microsoft.com/en-us/library/azure/dd179468.aspx).
-    client.create_container("wow", PublicAccess::Blob).unwrap();
 
-	// This call will list your containers.
-    let mut ret = client.list_containers().unwrap();
-    println!("{:?}", ret);
+  // This call will list your containers.
+  let containers = Container::list(&client).unwrap();
+  println!("{:?}", ret);
 
-	// This code will look for the "todelete" container and
-	// remove from Azure.
-    let mut to_delete = ret.iter_mut().find(|x| x.name == "todelete").unwrap();
-    to_delete.delete(&client).unwrap();
-    println!("{:?} deleted!", to_delete);
+  // This call will create a new Azure Container called "wow"
+  // with public blob access (see https://msdn.microsoft.com/en-us/library/azure/dd179468.aspx)
+  // if it doesn't exist already.
+  let cont = containers.iter().find(|x| x.name == container_name);
+  if let None = cont {
+  	Container::create(&client, container_name, PublicAccess::Blob).unwrap();
+  }
+
+  // this code will upload a file to the container just created.
+  {
+	use std::fs::metadata;
+	use std::fs::File;
+
+	let file_name: &'static str = "C:\\temp\\from_rust.txt";
+	let container_name: &'static str = "wow";
+
+	let metadata = metadata(file_name).unwrap();
+	let mut file = File::open(file_name).unwrap();
+
+	let new_blob = Blob {
+		name: "from_rust.txt".to_owned(),
+		snapshot_time: None,
+		last_modified: UTC::now(),
+		etag: "".to_owned(),
+		content_length: metadata.len(),
+		content_type: "application/octet-stream".parse::<Mime>().unwrap(),
+		content_encoding: None,
+		content_language: None,
+		content_md5: None,
+		cache_control: None,
+		x_ms_blob_sequence_number: None,
+		blob_type: BlobType::BlockBlob,
+		lease_status: LeaseStatus::Unlocked,
+		lease_state: LeaseState::Available,
+		lease_duration: None,
+		copy_id: None,
+		copy_status: None,
+		copy_source: None,
+		copy_progress: None,
+		copy_completion: None,
+		copy_status_description: None,
+	};
+
+	new_blob.put(&client,
+		 container_name,
+		 None,
+		 Some((&mut file, metadata.len())))
+		.unwrap();
+  }
+
+  // This code will look for the "todelete" container and
+  // remove from Azure.
+  let mut to_delete = ret.iter_mut().find(|x| x.name == "todelete").unwrap();
+  to_delete.delete(&client).unwrap();
+  println!("{:?} deleted!", to_delete);
 }
 ```
 

--- a/src/azure/core/ba512_range.rs
+++ b/src/azure/core/ba512_range.rs
@@ -1,0 +1,140 @@
+use std::str::FromStr;
+use std::fmt;
+use std::num::ParseIntError;
+use azure::core::range::Range;
+use std::convert::Into;
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct BA512Range {
+    start: u64,
+    end: u64,
+}
+
+impl BA512Range {
+    pub fn start(&self) -> u64 {
+        self.start
+    }
+    pub fn end(&self) -> u64 {
+        self.end
+    }
+
+    pub fn new(start: u64, end: u64) -> Result<BA512Range, Not512ByteAlignedError> {
+        if start % 512 != 0 {
+            return Err(Not512ByteAlignedError::StartRange(start));
+        }
+        if (end + 1) % 512 != 0 {
+            return Err(Not512ByteAlignedError::EndRange(end));
+        }
+
+        Ok(BA512Range {
+            start: start,
+            end: end,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Not512ByteAlignedError {
+    StartRange(u64),
+    EndRange(u64),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ParseError {
+    SplitNotFound,
+    ParseIntError(ParseIntError),
+    Not512ByteAlignedError(Not512ByteAlignedError),
+}
+
+impl From<ParseIntError> for ParseError {
+    fn from(pie: ParseIntError) -> ParseError {
+        ParseError::ParseIntError(pie)
+    }
+}
+
+impl From<Not512ByteAlignedError> for ParseError {
+    fn from(nae: Not512ByteAlignedError) -> ParseError {
+        ParseError::Not512ByteAlignedError(nae)
+    }
+}
+
+impl Into<Range> for BA512Range {
+    fn into(self) -> Range {
+        Range {
+            start: self.start(),
+            end: self.end(),
+        }
+    }
+}
+
+impl FromStr for BA512Range {
+    type Err = ParseError;
+    fn from_str(s: &str) -> Result<BA512Range, ParseError> {
+        let v = s.split("/").collect::<Vec<&str>>();
+        if v.len() != 2 {
+            return Err(ParseError::SplitNotFound);
+        }
+
+        let cp_start = try!(v[0].parse::<u64>());
+        let cp_end = try!(v[1].parse::<u64>());
+
+
+
+        Ok(try!(BA512Range::new(cp_start, cp_end)))
+    }
+}
+
+impl fmt::Display for BA512Range {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}/{}", self.start, self.end)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_512range_parse() {
+        let range = "0/511".parse::<BA512Range>().unwrap();
+
+        assert_eq!(range.start, 0);
+        assert_eq!(range.end, 511);
+    }
+
+    #[test]
+    #[should_panic(expected = "ParseIntError(ParseIntError { kind: InvalidDigit })")]
+    fn test_512range_parse_panic_1() {
+        "abba/2000".parse::<BA512Range>().unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "SplitNotFound")]
+    fn test_512range_parse_panic_2() {
+        "1000-2000".parse::<BA512Range>().unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "Not512ByteAlignedError(StartRange(7))")]
+    fn test_512range_invalid_start_range() {
+        "7/511".parse::<BA512Range>().unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "Not512ByteAlignedError(EndRange(100))")]
+    fn test_512range_invalid_end_range() {
+        "0/100".parse::<BA512Range>().unwrap();
+    }
+
+    #[test]
+    fn test_512range_display() {
+        let range = BA512Range {
+            start: 0,
+            end: 511,
+        };
+
+        let txt = format!("{}", range);
+
+        assert_eq!(txt, "0/511");
+    }
+}

--- a/src/azure/core/incompletevector.rs
+++ b/src/azure/core/incompletevector.rs
@@ -1,21 +1,63 @@
-// use std::ops::Index;
+use std::ops::Deref;
 
 #[derive(Debug)]
 pub struct IncompleteVector<T> {
-    next_marker: String,
+    next_marker: Option<String>,
     vector: Vec<T>,
 }
 
-impl<T> IncompleteVector<T> {
-    pub fn next_marker(&self) -> &str {
-        &self.next_marker
+#[allow(dead_code)]
+impl<'a, T> IncompleteVector<T> {
+    pub fn new(next_marker: Option<String>, vector: Vec<T>) -> IncompleteVector<T> {
+        IncompleteVector {
+            next_marker: next_marker,
+            vector: vector,
+        }
+    }
+
+    pub fn next_marker(&self) -> Option<&str> {
+        match self.next_marker {
+            Some(ref nm) => Some(nm),
+            None => None,
+        }
     }
 
     pub fn is_complete(&self) -> bool {
-        self.next_marker() == ""
+        self.next_marker().is_none()
+    }
+}
+
+impl<T> Deref for IncompleteVector<T> {
+    type Target = [T];
+
+    fn deref(&self) -> &[T] {
+        &self.vector
+    }
+}
+
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_incomplete_vector_complete() {
+        let v = vec![0, 1, 2, 3, 4, 5];
+        let ic = IncompleteVector::new(None, v);
+
+        assert_eq!(ic.is_complete(), true);
     }
 
-    pub fn vector(&self) -> &[T] {
-        &self.vector
+    #[test]
+    fn test_incomplete_vector_incomplete() {
+        let v = vec![0, 1, 2, 3, 4, 5];
+        let ic = IncompleteVector::new(Some("aaa".to_owned()), v);
+
+        assert_eq!(ic.is_complete(), false);
+    }
+
+    #[test]
+    fn test_incomplete_vector_deref() {
+        let v = vec![0, 1, 2, 3, 4, 5];
+        let ic = IncompleteVector::new(None, v);
+        assert_eq!(ic[0], 0);
     }
 }

--- a/src/azure/core/mod.rs
+++ b/src/azure/core/mod.rs
@@ -28,8 +28,10 @@ pub mod parsing;
 #[macro_use]
 pub mod enumerations;
 pub mod incompletevector;
-pub mod range;
 pub mod lease_id;
+
+pub mod range;
+pub mod ba512_range;
 
 #[derive(Debug, Copy, Clone)]
 pub enum HTTPMethod {

--- a/src/azure/core/range.rs
+++ b/src/azure/core/range.rs
@@ -1,6 +1,8 @@
 use std::str::FromStr;
 use std::fmt;
 use std::num::ParseIntError;
+use std::convert::From;
+use azure::core::ba512_range::BA512Range;
 
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct Range {
@@ -12,6 +14,15 @@ pub struct Range {
 pub enum ParseError {
     SplitNotFound,
     ParseIntError(ParseIntError),
+}
+
+impl<'a> From<&'a BA512Range> for Range {
+    fn from(ba: &'a BA512Range) -> Range {
+        Range {
+            start: ba.start(),
+            end: ba.end(),
+        }
+    }
 }
 
 impl From<ParseIntError> for ParseError {

--- a/src/azure/storage/blob/list_blob_options.rs
+++ b/src/azure/storage/blob/list_blob_options.rs
@@ -1,0 +1,43 @@
+#[derive(Debug, Clone, PartialEq)]
+pub struct ListBlobOptions {
+    pub max_results: u32,
+    pub include_snapshots: bool,
+    pub include_metadata: bool,
+    pub include_uncommittedblobs: bool,
+    pub include_copy: bool,
+    pub next_marker: Option<String>,
+}
+
+pub const LIST_BLOB_OPTIONS_DEFAULT: ListBlobOptions = ListBlobOptions {
+    max_results: 5000,
+    include_snapshots: false,
+    include_metadata: false,
+    include_uncommittedblobs: false,
+    include_copy: false,
+    next_marker: None,
+};
+
+impl ListBlobOptions {
+    pub fn new(max_results: u32,
+               include_snapshots: bool,
+               include_metadata: bool,
+               include_uncommittedblobs: bool,
+               include_copy: bool,
+               next_marker: Option<&str>)
+               -> ListBlobOptions {
+
+        let nm = match next_marker {
+            Some(s) => Some(s.to_owned()),
+            None => None,
+        };
+
+        ListBlobOptions {
+            max_results: max_results,
+            include_snapshots: include_snapshots,
+            include_metadata: include_metadata,
+            include_uncommittedblobs: include_uncommittedblobs,
+            include_copy: include_copy,
+            next_marker: nm,
+        }
+    }
+}

--- a/src/azure/storage/client.rs
+++ b/src/azure/storage/client.rs
@@ -2,12 +2,8 @@ use hyper::header::Headers;
 use hyper::client::response::Response;
 use hyper::error::Error;
 
-use azure::storage::container;
-use azure::storage::container::Container;
-
 use std::io::Read;
 
-use azure::core::errors;
 use azure::core::{HTTPMethod, perform_request};
 
 #[derive(Debug)]
@@ -19,6 +15,14 @@ pub struct Client {
 
 
 impl Client {
+    pub fn new(account: &str, key: &str, use_https: bool) -> Client {
+        Client {
+            account: account.to_owned(),
+            key: key.to_owned(),
+            use_https: use_https,
+        }
+    }
+
     pub fn account(&self) -> &str {
         &self.account
     }
@@ -39,19 +43,6 @@ impl Client {
         &self.key
     }
 
-    #[inline]
-    pub fn list_containers(&self) -> Result<Vec<Container>, errors::AzureError> {
-        Container::list(self)
-    }
-
-    #[inline]
-    pub fn create_container(&self,
-                            container_name: &str,
-                            pa: container::PublicAccess)
-                            -> Result<(), errors::AzureError> {
-        Container::create(self, container_name, pa)
-    }
-
     pub fn perform_request(&self,
                            uri: &str,
                            method: HTTPMethod,
@@ -59,13 +50,5 @@ impl Client {
                            request_body: Option<(&mut Read, u64)>)
                            -> Result<Response, Error> {
         perform_request(uri, method, &self.key, headers, request_body)
-    }
-}
-
-pub fn new(account: &str, key: &str, use_https: bool) -> Client {
-    Client {
-        account: account.to_owned(),
-        key: key.to_owned(),
-        use_https: use_https,
     }
 }

--- a/src/azure/storage/container/mod.rs
+++ b/src/azure/storage/container/mod.rs
@@ -1,3 +1,4 @@
+
 use azure::core;
 use azure::core::errors;
 use azure::core::enumerations;
@@ -6,12 +7,6 @@ use azure::core::parsing::{traverse, cast_must, cast_optional};
 use azure::storage::{LeaseStatus, LeaseState, LeaseDuration};
 use azure::storage::client::Client;
 
-use azure::core::{XMSRange, XMSLeaseId, XMSRangeGetContentMD5};
-
-use azure::storage::blob;
-use azure::storage::blob::Blob;
-// use azure::core::parsing;
-// use hyper::error;
 use hyper::header::Headers;
 use hyper::status::StatusCode;
 
@@ -21,9 +16,6 @@ use chrono::UTC;
 
 use std::io::Read;
 
-use azure::core::lease_id::LeaseId;
-use azure::core::range::Range;
-
 use std::fmt;
 
 use xml::Element;
@@ -31,13 +23,14 @@ use xml::Element;
 use azure::core::errors::TraversingError;
 use azure::core::parsing::FromStringOptional;
 
+header! { (XMSBlobPublicAccess, "x-ms-blob-public-access") => [PublicAccess] }
+
 create_enum!(PublicAccess,
                             (None,          "none"),
                             (Container,     "container"),
                             (Blob,          "blob")
 );
 
-header! { (XMSBlobPublicAccess, "x-ms-blob-public-access") => [PublicAccess] }
 
 #[derive(Debug)]
 pub struct Container {
@@ -97,126 +90,6 @@ impl Container {
 
         try!(errors::check_status(&mut resp, StatusCode::Accepted));
         Ok(())
-    }
-
-    pub fn list_blobs(&self,
-                      c: &Client,
-                      include_snapshots: bool,
-                      include_metadata: bool,
-                      include_uncommittedblobs: bool,
-                      include_copy: bool)
-                      -> Result<Vec<blob::Blob>, core::errors::AzureError> {
-
-        let mut include = String::new();
-        if include_snapshots {
-            include = include + "snapshots";
-        }
-        if include_metadata {
-            if include.is_empty() {
-                include = include + ",";
-            }
-            include = include + "metadata";
-        }
-        if include_uncommittedblobs {
-            if include.is_empty() {
-                include = include + ",";
-            }
-            include = include + "uncommittedblobs";
-        }
-        if include_copy {
-            if include.is_empty() {
-                include = include + ",";
-            }
-            include = include + "copy";
-        }
-
-        let mut uri = format!("{}://{}.blob.core.windows.net/{}?restype=container&comp=list",
-                              c.auth_scheme(),
-                              c.account(),
-                              self.name);
-
-        if include.is_empty() {
-            uri = format!("{}&include={}", uri, include);
-        }
-
-        let mut resp = try!(c.perform_request(&uri, core::HTTPMethod::Get, &Headers::new(), None));
-
-        try!(errors::check_status(&mut resp, StatusCode::Ok));
-
-        let mut resp_s = String::new();
-        match resp.read_to_string(&mut resp_s) {
-            Ok(_) => (),
-            Err(err) => return Err(errors::new_from_ioerror_string(err.to_string())),
-        };
-
-        println!("resp_s == {:?}\n\n", resp_s);
-
-        let sp = &resp_s;
-        let elem: Element = match sp.parse() {
-            Ok(res) => res,
-            Err(err) => return Err(errors::new_from_xmlerror_string(err.to_string())),
-        };
-
-        let mut v = Vec::new();
-        for node_blob in try!(traverse(&elem, &["Blobs", "Blob"], true)) {
-            // println!("{:?}", blob);
-            v.push(try!(Blob::parse(node_blob)));
-        }
-
-        Ok(v)
-    }
-
-    pub fn get_blob(&self,
-                    c: &Client,
-                    blob_name: &str,
-                    snapshot: Option<&DateTime<UTC>>,
-                    range: Option<&Range>,
-                    lease_id: Option<&LeaseId>)
-                    -> Result<(blob::Blob, Box<Read>), core::errors::AzureError> {
-        let mut uri = format!("{}://{}.blob.core.windows.net/{}/{}",
-                              c.auth_scheme(),
-                              c.account(),
-                              self.name,
-                              blob_name);
-
-        if let Some(snapshot) = snapshot {
-            uri = format!("{}?snapshot={}", uri, snapshot.to_rfc2822());
-        }
-
-        let uri = uri;
-
-        println!("uri == {:?}", uri);
-
-        let mut headers = Headers::new();
-
-        if let Some(r) = range {
-            headers.set(XMSRange(r.clone()));
-
-            // if range is < 4MB request md5
-            if r.end - r.start <= 1024 * 1024 * 4 {
-                headers.set(XMSRangeGetContentMD5(true));
-            }
-        }
-
-        if let Some(l) = lease_id {
-            headers.set(XMSLeaseId(l.clone()));
-        }
-
-
-        let mut resp = try!(c.perform_request(&uri, core::HTTPMethod::Get, &headers, None));
-
-        // if we have requested a range the response code should be 207 (partial content)
-        // otherwise 200 (ok).
-        if let Some(_) = range {
-            try!(errors::check_status(&mut resp, StatusCode::PartialContent));
-        } else {
-            try!(errors::check_status(&mut resp, StatusCode::Ok));
-        }
-
-        let blob = try!(Blob::from_headers(blob_name, &resp.headers));
-        let r: Box<Read> = Box::new(resp);
-
-        Ok((blob, r))
     }
 
     pub fn create(c: &Client,

--- a/src/azure/storage/mod.rs
+++ b/src/azure/storage/mod.rs
@@ -1,8 +1,6 @@
 pub mod client;
-#[macro_use]
-pub mod blob;
 pub mod container;
-
+pub mod blob;
 
 use std::fmt;
 use std::str::FromStr;


### PR DESCRIPTION
## [0.0.6](https://github.com/MindFlavor/AzureSDKForRust/releases/tag/0.0.6) (2016-01-12)

**Implemented features:**
* Added support for max_results in list_blobs. Now you can limit how many blobs could be returned by a single call.
* Added support for next_marker in list_blobs. Now you can continue enumerating your blobs in subsequent calls.
* Added put page for page blobs.
* Added clear page for page blobs.

**Refactoring:**
* Added page constraints (512-bytes aligned).
* Most methods moved from storage::Client to correct structs (ie storage::container::Container and storage::blob::Blob).
* Moved list_blobs options in a separate structure (```azure::storage::blob::ListBlobOptions```).