### PR TITLE
Implemented put_block and exported options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,40 @@
 # Change Log
 
+
+## [0.0.7](https://github.com/MindFlavor/AzureSDKForRust/releases/tag/0.0.7) (2015-01-14)
+
+**Implemented features:**
+* Added support for ```put_block``` in ```Blob```.
+* Added support for ```filter```  in ```Blob::list```. Now you can filter the blobs to find specifying the starting string.
+* Added support for ```timeout``` in ```Blob::list```.
+* Added support for ```timeout```, ```prefix``` and ```max_results```  in ```Container::list```.
+* Added support for ```max_results``` in ```Container::list```. Now you can limit how many containers could be returned by a single call.
+* Added support for ```next_marker``` in ```Container::list```. Now you can continue enumerating your containers in subsequent calls.
+
+**Refactoring:**
+* Moved ```Container::list``` options in a separate structure (```azure::storage::container::ListContainerOptions```).
+* Moved ```Blob::put_page``` options in a separate structure (```azure::storage::blob::PutPageOptions```).
+
+**Bugfixes:**
+* Corrected the format bug in ```azure::core::range::Range``` and ```azure::core::range::ba512_range::BA512Range```. Previously the string returned was
+formatted as ```{}/{}``` which is invalid for the ```x-ms-range``` header. Now the format is ```bytes={}-{}``` as expected. I still need to figure out if
+  I need to change the ```FromStr``` trait too to match the change.
+
+**Removed methods:**
+* Removed ```ListBlobOptions::new``` as it was just useless boilerplate.
+
 ## [0.0.6](https://github.com/MindFlavor/AzureSDKForRust/releases/tag/0.0.6) (2016-01-12)
 
 **Implemented features:**
-* Added support for max_results in list_blobs. Now you can limit how many blobs could be returned by a single call.
-* Added support for next_marker in list_blobs. Now you can continue enumerating your blobs in subsequent calls.
-* Added put page for page blobs.
-* Added clear page for page blobs.
+* Added support for max_results in ```Blob::list```. Now you can limit how many blobs could be returned by a single call.
+* Added support for next_marker in ```Blob::list```. Now you can continue enumerating your blobs in subsequent calls.
+* Added ```put page``` for page blobs.
+* Added ```clear page``` for page blobs.
 
 **Refactoring:**
 * Added page constraints (512-bytes aligned).
-* Most methods moved from storage::Client to correct structs (ie storage::container::Container and storage::blob::Blob).
-* Moved list_blobs options in a separate structure (```azure::storage::blob::ListBlobOptions```).
+* Most methods moved from ```storage::Client``` to correct structs (ie ```storage::container::Container``` and ```storage::blob::Blob```).
+* Moved ```Blob::list``` options in a separate structure (```azure::storage::blob::ListBlobOptions```).
 
 ## [0.0.5](https://github.com/MindFlavor/AzureSDKForRust/releases/tag/0.0.5) (2016-01-05)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,9 @@ version = "0.0.6"
 dependencies = [
  "RustyXML 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -23,6 +25,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -48,6 +58,15 @@ dependencies = [
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.46 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -152,6 +171,14 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "memchr"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "mime"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,6 +263,21 @@ dependencies = [
  "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "regex"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rust-crypto"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ rust-crypto = "^0.2"
 rustc-serialize = "*"
 RustyXML = "*"
 mime = "*"
+log = "0.3"
+env_logger = "0.3"
 
 [dependencies.hyper]
 version = "*"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ extern crate mime;
 use azure::storage::{LeaseState, LeaseStatus};
 use azure::storage::client::Client;
 use azure::storage::blob::{Blob, BlobType};
-use azure::storage::container::{Container, PublicAccess};
+use azure::storage::container::{Container, PublicAccess, LIST_CONTAINER_OPTIONS_DEFAULT};
 
 use chrono::UTC;
 
@@ -41,7 +41,7 @@ fn main() {
 
 
   // This call will list your containers.
-  let containers = Container::list(&client).unwrap();
+  let containers = Container::list(&client, &LIST_CONTAINER_OPTIONS_DEFAULT).unwrap();
   println!("{:?}", ret);
 
   // This call will create a new Azure Container called "wow"
@@ -128,5 +128,7 @@ If you want to contribute please do! No formality required! :wink:
 |Put blob|[https://msdn.microsoft.com/en-us/library/azure/dd179451.aspx](https://msdn.microsoft.com/en-us/library/azure/dd179451.aspx)|
 |Put blob page|[https://msdn.microsoft.com/en-us/library/azure/dd179451.aspx](https://msdn.microsoft.com/en-us/library/azure/dd179451.aspx)|
 |Clear blob page|[https://msdn.microsoft.com/en-us/library/azure/dd179451.aspx](https://msdn.microsoft.com/en-us/library/azure/dd179451.aspx)|
+|Put block|[https://msdn.microsoft.com/en-us/library/azure/dd135726.aspx](https://msdn.microsoft.com/en-us/library/azure/dd135726.aspx)|
+
 ## License
 This project is published under [The MIT License (MIT)](LICENSE).

--- a/src/azure/core/ba512_range.rs
+++ b/src/azure/core/ba512_range.rs
@@ -31,6 +31,11 @@ impl BA512Range {
             end: end,
         })
     }
+
+    #[inline]
+    pub fn len(&self) -> u64 {
+        self.end - self.start + 1
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -86,7 +91,7 @@ impl FromStr for BA512Range {
 
 impl fmt::Display for BA512Range {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}/{}", self.start, self.end)
+        write!(f, "bytes={}-{}", self.start, self.end)
     }
 }
 
@@ -135,6 +140,6 @@ mod test {
 
         let txt = format!("{}", range);
 
-        assert_eq!(txt, "0/511");
+        assert_eq!(txt, "bytes=0-511");
     }
 }

--- a/src/azure/core/mod.rs
+++ b/src/azure/core/mod.rs
@@ -57,7 +57,7 @@ header! { (XMSLeaseState, "x-ms-lease-state") => [LeaseState] }
 header! { (XMSLeaseDuration, "x-ms-lease-duration") => [LeaseDuration] }
 header! { (ETag, "ETag") => [String] }
 header! { (XMSRangeGetContentMD5, "x-ms-range-get-content-md5") => [bool] }
-
+header! { (XMSClientRequestId, "x-ms-client-request-id") => [String] }
 
 pub fn generate_authorization(h: &Headers,
                               u: &url::Url,

--- a/src/azure/core/range.rs
+++ b/src/azure/core/range.rs
@@ -51,7 +51,7 @@ impl FromStr for Range {
 
 impl fmt::Display for Range {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}/{}", self.start, self.end)
+        write!(f, "bytes={}-{}", self.start, self.end)
     }
 }
 
@@ -88,6 +88,6 @@ mod test {
 
         let txt = format!("{}", range);
 
-        assert_eq!(txt, "100/500");
+        assert_eq!(txt, "bytes=100-500");
     }
 }

--- a/src/azure/storage/blob/list_blob_options.rs
+++ b/src/azure/storage/blob/list_blob_options.rs
@@ -6,6 +6,8 @@ pub struct ListBlobOptions {
     pub include_uncommittedblobs: bool,
     pub include_copy: bool,
     pub next_marker: Option<String>,
+    pub prefix: Option<String>,
+    pub timeout: Option<u64>,
 }
 
 pub const LIST_BLOB_OPTIONS_DEFAULT: ListBlobOptions = ListBlobOptions {
@@ -15,29 +17,8 @@ pub const LIST_BLOB_OPTIONS_DEFAULT: ListBlobOptions = ListBlobOptions {
     include_uncommittedblobs: false,
     include_copy: false,
     next_marker: None,
+    prefix: None,
+    timeout: None,
 };
 
-impl ListBlobOptions {
-    pub fn new(max_results: u32,
-               include_snapshots: bool,
-               include_metadata: bool,
-               include_uncommittedblobs: bool,
-               include_copy: bool,
-               next_marker: Option<&str>)
-               -> ListBlobOptions {
-
-        let nm = match next_marker {
-            Some(s) => Some(s.to_owned()),
-            None => None,
-        };
-
-        ListBlobOptions {
-            max_results: max_results,
-            include_snapshots: include_snapshots,
-            include_metadata: include_metadata,
-            include_uncommittedblobs: include_uncommittedblobs,
-            include_copy: include_copy,
-            next_marker: nm,
-        }
-    }
-}
+impl ListBlobOptions {}

--- a/src/azure/storage/blob/put_block_options.rs
+++ b/src/azure/storage/blob/put_block_options.rs
@@ -1,0 +1,14 @@
+use azure::core::lease_id::LeaseId;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PutBlockOptions {
+    pub lease_id: Option<LeaseId>,
+    pub timeout: Option<u64>,
+    pub request_id: Option<String>,
+}
+
+pub const PUT_BLOCK_OPTIONS_DEFAULT: PutBlockOptions = PutBlockOptions {
+    timeout: None,
+    lease_id: None,
+    request_id: None,
+};

--- a/src/azure/storage/blob/put_options.rs
+++ b/src/azure/storage/blob/put_options.rs
@@ -1,0 +1,12 @@
+use azure::core::lease_id::LeaseId;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PutOptions {
+    pub lease_id: Option<LeaseId>,
+    pub timeout: Option<u64>,
+}
+
+pub const PUT_OPTIONS_DEFAULT: PutOptions = PutOptions {
+    timeout: None,
+    lease_id: None,
+};

--- a/src/azure/storage/blob/put_page_options.rs
+++ b/src/azure/storage/blob/put_page_options.rs
@@ -1,0 +1,12 @@
+use azure::core::lease_id::LeaseId;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PutPageOptions {
+    pub lease_id: Option<LeaseId>,
+    pub timeout: Option<u64>,
+}
+
+pub const PUT_PAGE_OPTIONS_DEFAULT: PutPageOptions = PutPageOptions {
+    timeout: None,
+    lease_id: None,
+};

--- a/src/azure/storage/container/list_container_options.rs
+++ b/src/azure/storage/container/list_container_options.rs
@@ -1,0 +1,16 @@
+#[derive(Debug, Clone, PartialEq)]
+pub struct ListContainerOptions {
+    pub max_results: u32,
+    pub include_metadata: bool,
+    pub next_marker: Option<String>,
+    pub prefix: Option<String>,
+    pub timeout: Option<u64>,
+}
+
+pub const LIST_CONTAINER_OPTIONS_DEFAULT: ListContainerOptions = ListContainerOptions {
+    max_results: 5000,
+    include_metadata: false,
+    next_marker: None,
+    prefix: None,
+    timeout: None,
+};

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,11 +8,18 @@ extern crate xml;
 #[macro_use]
 extern crate mime;
 
+#[macro_use]
+extern crate log;
+extern crate env_logger;
+
 
 use azure::storage::{LeaseState, LeaseStatus};
 use azure::storage::client::Client;
-use azure::storage::blob::{Blob, BlobType, ListBlobOptions, LIST_BLOB_OPTIONS_DEFAULT};
-use azure::storage::container::{Container, PublicAccess};
+use azure::storage::blob::{Blob, BlobType, ListBlobOptions, LIST_BLOB_OPTIONS_DEFAULT,
+                           PUT_OPTIONS_DEFAULT, PUT_BLOCK_OPTIONS_DEFAULT,
+                           PUT_PAGE_OPTIONS_DEFAULT};
+use azure::storage::container::{Container, PublicAccess, LIST_CONTAINER_OPTIONS_DEFAULT};
+use azure::core::ba512_range::BA512Range;
 
 // use azure::storage::container::PublicAccess;
 
@@ -25,6 +32,8 @@ use chrono::UTC;
 use mime::Mime;
 
 fn main() {
+    env_logger::init().unwrap();
+
     let azure_storage_account = match std::env::var("AZURE_STORAGE_ACCOUNT") {
         Ok(val) => val,
         Err(_) => {
@@ -44,28 +53,12 @@ fn main() {
     // client.create_container("balocco3", PublicAccess::Blob).unwrap();
     // // println!("{:?}", new);
     //
-    let ret = Container::list(&client).unwrap();
-    println!("{:?}", ret);
 
+    info!("Beginning tests");
 
-    let lbo = ListBlobOptions::new(10, true, true, true, true, None);
-    let mut lbo2 = LIST_BLOB_OPTIONS_DEFAULT.clone();
-    lbo2.max_results = 2;
+    put_block_blob(&client);
 
-    loop {
-        let uc = Blob::list(&client, "rust", &lbo2).unwrap();
-
-        println!("uc {:?}\n\n", uc);
-
-        if !uc.is_complete() {
-            lbo2.next_marker = Some(uc.next_marker().unwrap().to_owned());
-        } else {
-            break;
-        }
-    }
-
-
-    return;
+    put_page_blob(&client);
 
     // {
     //     let vhds = ret.iter_mut().find(|x| x.name == "canotto").unwrap();
@@ -145,60 +138,7 @@ fn main() {
     // }
 
 
-    {
-        use std::fs::metadata;
-        use std::fs::File;
 
-        let blob_name: &'static str = "MindDB_Log.ldf";
-        let file_name: &'static str = "C:\\temp\\MindDB_Log.ldf";
-        let container_name: &'static str = "rust";
-        let metadata = metadata(file_name).unwrap();
-        let mut file = File::open(file_name).unwrap();
-
-        {
-            let containers = Container::list(&client).unwrap();
-
-            let cont = containers.iter().find(|x| x.name == container_name);
-            if let None = cont {
-                Container::create(&client, container_name, PublicAccess::Blob).unwrap();
-            }
-        }
-
-        // align to 512 bytes
-        let content_length = metadata.len() % 512 + metadata.len();
-
-        let new_blob = Blob {
-            name: blob_name.to_owned(),
-            container_name: container_name.to_owned(),
-            snapshot_time: None,
-            last_modified: UTC::now(),
-            etag: "".to_owned(),
-            content_length: content_length,
-            content_type: "application/octet-stream".parse::<Mime>().unwrap(),
-            content_encoding: None,
-            content_language: None,
-            content_md5: None,
-            cache_control: None,
-            x_ms_blob_sequence_number: None,
-            blob_type: BlobType::PageBlob,
-            lease_status: LeaseStatus::Unlocked,
-            lease_state: LeaseState::Available,
-            lease_duration: None,
-            copy_id: None,
-            copy_status: None,
-            copy_source: None,
-            copy_progress: None,
-            copy_completion: None,
-            copy_status_description: None,
-        };
-
-        new_blob.put(&client, None, None)
-                .unwrap();
-
-        println!("created {:?}", new_blob);
-
-        // new_blob.put_page(undefined)
-    }
 
     // bal2.delete(&client).unwrap();
     // println!("{:?} deleted!", bal2);
@@ -206,4 +146,163 @@ fn main() {
     // let ret = client.delete_container("balocco2").unwrap();
     // println!("{:?}", ret);
     // inc_a!("main");
+}
+
+fn list_blobs(client: &Client) {
+    println!("running list_blobs");
+
+    let mut lbo2 = LIST_BLOB_OPTIONS_DEFAULT.clone();
+    lbo2.max_results = 15;
+
+    loop {
+        let uc = Blob::list(&client, "rust", &lbo2).unwrap();
+
+        println!("uc {:?}\n\n", uc);
+
+        if !uc.is_complete() {
+            lbo2.next_marker = Some(uc.next_marker().unwrap().to_owned());
+        } else {
+            break;
+        }
+    }
+}
+
+fn list_containers(client: &Client) {
+    println!("running list_containers");
+
+    let mut lco = LIST_CONTAINER_OPTIONS_DEFAULT.clone();
+    lco.max_results = 2;
+    loop {
+        let ret = Container::list(&client, &lco).unwrap();
+
+        println!("ret {:?}\n\n", ret);
+
+        if !ret.is_complete() {
+            lco.next_marker = Some(ret.next_marker().unwrap().to_owned());
+        } else {
+            break;
+        }
+    }
+}
+
+
+fn put_block_blob(client: &Client) {
+    use std::fs::metadata;
+    use std::fs::File;
+
+    println!("\nrunning put_block_blob");
+
+    let blob_name: &'static str = "Win64OpenSSL-1_0_2e.exe";
+    let file_name: &'static str = "C:\\temp\\Win64OpenSSL-1_0_2e.exe";
+    let container_name: &'static str = "rust";
+    let metadata = metadata(file_name).unwrap();
+    let mut file = File::open(file_name).unwrap();
+
+    let content_length = metadata.len();
+
+    {
+        let containers = Container::list(&client, &LIST_CONTAINER_OPTIONS_DEFAULT).unwrap();
+
+        let cont = containers.iter().find(|x| x.name == container_name);
+        if let None = cont {
+            Container::create(client, container_name, PublicAccess::Blob).unwrap();
+        }
+    }
+
+    let new_blob = Blob {
+        name: blob_name.to_owned(),
+        container_name: container_name.to_owned(),
+        snapshot_time: None,
+        last_modified: UTC::now(),
+        etag: "".to_owned(),
+        content_length: content_length,
+        content_type: "application/octet-stream".parse::<Mime>().unwrap(),
+        content_encoding: None,
+        content_language: None,
+        content_md5: None,
+        cache_control: None,
+        x_ms_blob_sequence_number: None,
+        blob_type: BlobType::BlockBlob,
+        lease_status: LeaseStatus::Unlocked,
+        lease_state: LeaseState::Available,
+        lease_duration: None,
+        copy_id: None,
+        copy_status: None,
+        copy_source: None,
+        copy_progress: None,
+        copy_completion: None,
+        copy_status_description: None,
+    };
+
+    new_blob.put_block(&client,
+                       "block_name",
+                       &PUT_BLOCK_OPTIONS_DEFAULT,
+                       (&mut file, 1024 * 1024))
+            .unwrap();
+
+    println!("created {:?}", new_blob);
+}
+
+
+fn put_page_blob(client: &Client) {
+    use std::fs::metadata;
+    use std::fs::File;
+
+    println!("\nrunning put_page_blob");
+
+    let blob_name: &'static str = "MindDB_Log.ldf";
+    let file_name: &'static str = "C:\\temp\\MindDB_Log.ldf";
+    let container_name: &'static str = "rust";
+    let metadata = metadata(file_name).unwrap();
+    let mut file = File::open(file_name).unwrap();
+
+    {
+        let containers = Container::list(&client, &LIST_CONTAINER_OPTIONS_DEFAULT).unwrap();
+
+        let cont = containers.iter().find(|x| x.name == container_name);
+        if let None = cont {
+            Container::create(client, container_name, PublicAccess::Blob).unwrap();
+        }
+    }
+
+    // align to 512 bytes
+    let content_length = metadata.len() % 512 + metadata.len();
+
+    let new_blob = Blob {
+        name: blob_name.to_owned(),
+        container_name: container_name.to_owned(),
+        snapshot_time: None,
+        last_modified: UTC::now(),
+        etag: "".to_owned(),
+        content_length: content_length,
+        content_type: "application/octet-stream".parse::<Mime>().unwrap(),
+        content_encoding: None,
+        content_language: None,
+        content_md5: None,
+        cache_control: None,
+        x_ms_blob_sequence_number: None,
+        blob_type: BlobType::PageBlob,
+        lease_status: LeaseStatus::Unlocked,
+        lease_state: LeaseState::Available,
+        lease_duration: None,
+        copy_id: None,
+        copy_status: None,
+        copy_source: None,
+        copy_progress: None,
+        copy_completion: None,
+        copy_status_description: None,
+    };
+
+    new_blob.put(&client, &PUT_OPTIONS_DEFAULT, None)
+            .unwrap();
+
+    let range = BA512Range::new(0, 1024 * 1024 - 1).unwrap();
+
+    new_blob.put_page(client,
+                      &range, // 1MB
+                      &PUT_PAGE_OPTIONS_DEFAULT,
+                      (&mut file, range.len()))
+            .unwrap();
+
+    println!("created {:?}", new_blob);
 }


### PR DESCRIPTION
## [0.0.7](https://github.com/MindFlavor/AzureSDKForRust/releases/tag/0.0.7) (2015-01-14)

**Implemented features:**
* Added support for ```put_block``` in ```Blob```.
* Added support for ```filter```  in ```Blob::list```. Now you can filter the blobs to find specifying the starting string.
* Added support for ```timeout``` in ```Blob::list```.
* Added support for ```timeout```, ```prefix``` and ```max_results```  in ```Container::list```.
* Added support for ```max_results``` in ```Container::list```. Now you can limit how many containers could be returned by a single call.
* Added support for ```next_marker``` in ```Container::list```. Now you can continue enumerating your containers in subsequent calls.

**Refactoring:**
* Moved ```Container::list``` options in a separate structure (```azure::storage::container::ListContainerOptions```).
* Moved ```Blob::put_page``` options in a separate structure (```azure::storage::blob::PutPageOptions```).

**Bugfixes:**
* Corrected the format bug in ```azure::core::range::Range``` and ```azure::core::range::ba512_range::BA512Range```. Previously the string returned was
formatted as ```{}/{}``` which is invalid for the ```x-ms-range``` header. Now the format is ```bytes={}-{}``` as expected. I still need to figure out if
  I need to change the ```FromStr``` trait too to match the change.

**Removed methods:**
* Removed ```ListBlobOptions::new``` as it was just useless boilerplate.