### PR TITLE
Lease blob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
-# Change Log
+git# Change Log
 
 ## [0.1.1](https://github.com/MindFlavor/AzureSDKForRust/releases/tag/0.0.7) (yet-to-publish)
 
 **Implemented features:**
+* Lease blob (https://msdn.microsoft.com/library/azure/ee691972.aspx).
 
 **Refactoring:**
+* Renamed ```azure::core::lease_id``` module in ```azure::core::lease```.
+* Moved lease enumerations in ```azure::core::lease``` module.
 
 **Bugfixes:**
 * Added the non-doc option for the bin test file:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 git# Change Log
 
-## [0.1.1](https://github.com/MindFlavor/AzureSDKForRust/releases/tag/0.0.7) (yet-to-publish)
+## [0.1.1](https://github.com/MindFlavor/AzureSDKForRust/releases/tag/0.0.7) (2016-01-18)
 
 **Implemented features:**
 * Lease blob (https://msdn.microsoft.com/library/azure/ee691972.aspx).
@@ -16,8 +16,6 @@ git# Change Log
 name = "main"
 doc = false
 ```
-
-**Removed methods:**
 
 ## [0.1.0](https://github.com/MindFlavor/AzureSDKForRust/releases/tag/0.0.8) (2015-01-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 **Refactoring:**
 
 **Bugfixes:**
+* Added the non-doc option for the bin test file:
+```rust
+[[bin]]
+name = "main"
+doc = false
+```
 
 **Removed methods:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## [0.1.1](https://github.com/MindFlavor/AzureSDKForRust/releases/tag/0.0.7) (yet-to-publish)
+
+**Implemented features:**
+
+**Refactoring:**
+
+**Bugfixes:**
+
+**Removed methods:**
+
 ## [0.1.0](https://github.com/MindFlavor/AzureSDKForRust/releases/tag/0.0.8) (2015-01-16)
 
 **Implemented features:**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,6 +11,7 @@ dependencies = [
  "rust-crypto 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.5.2 (git+https://github.com/servo/rust-url)",
+ "uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "azure_sdk_for_rust"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "RustyXML 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,10 @@ name = "azure_sdk_for_rust"
 version = "0.1.0"
 authors = ["Francesco Cogno <francesco.cogno@outlook.com>"]
 
+[[bin]]
+name = "main"
+doc = false
+
 [dependencies]
 chrono = "*"
 rust-crypto = "^0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ RustyXML = "*"
 mime = "*"
 log = "0.3"
 env_logger = "0.3"
+uuid = "^0.1"
 
 [dependencies.hyper]
 version = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_sdk_for_rust"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Francesco Cogno <francesco.cogno@outlook.com>"]
 
 [[bin]]

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ If you want to contribute please do! No formality required! :wink:
 |Put blob page|[https://msdn.microsoft.com/en-us/library/azure/dd179451.aspx](https://msdn.microsoft.com/en-us/library/azure/dd179451.aspx)|
 |Clear blob page|[https://msdn.microsoft.com/en-us/library/azure/dd179451.aspx](https://msdn.microsoft.com/en-us/library/azure/dd179451.aspx)|
 |Put block|[https://msdn.microsoft.com/en-us/library/azure/dd135726.aspx](https://msdn.microsoft.com/en-us/library/azure/dd135726.aspx)|
+|Lease blob|[https://msdn.microsoft.com/library/azure/ee691972.aspx](https://msdn.microsoft.com/library/azure/ee691972.aspx)|
 
 ## License
 This project is published under [The MIT License (MIT)](LICENSE).

--- a/src/azure/core/lease.rs
+++ b/src/azure/core/lease.rs
@@ -2,6 +2,36 @@ use std::str::FromStr;
 use std::string::ParseError;
 use std::fmt::{Display, Formatter};
 use std::fmt;
+use azure::core::enumerations;
+use azure::core::errors::TraversingError;
+use azure::core::parsing::FromStringOptional;
+
+create_enum!(LeaseStatus,
+                            (Locked,        "locked"),
+                            (Unlocked,      "unlocked")
+);
+
+create_enum!(LeaseState,
+                            (Available,     "available"),
+                            (Leased,        "leased"),
+                            (Expired,       "expired"),
+                            (Breaking,      "breaking"),
+                            (Broken,        "broken")
+);
+
+create_enum!(LeaseDuration,
+                            (Infinite,      "infinite"),
+                            (Fixed,         "fixed")
+);
+
+create_enum!(LeaseAction,
+                            (Acquire,      "acquire"),
+                            (Renew,         "renew "),
+                            (Change,        "change"),
+                            (Release,        "release "),
+                            (Break,         "break")
+);
+
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct LeaseId {

--- a/src/azure/core/lease.rs
+++ b/src/azure/core/lease.rs
@@ -5,6 +5,7 @@ use std::fmt;
 use azure::core::enumerations;
 use azure::core::errors::TraversingError;
 use azure::core::parsing::FromStringOptional;
+use uuid::Uuid;
 
 create_enum!(LeaseStatus,
                             (Locked,        "locked"),
@@ -32,55 +33,4 @@ create_enum!(LeaseAction,
                             (Break,         "break")
 );
 
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct LeaseId {
-    id: String,
-}
-
-impl LeaseId {
-    pub fn new(s: &str) -> LeaseId {
-        LeaseId { id: s.to_owned() }
-    }
-}
-
-impl FromStr for LeaseId {
-    type Err = ParseError;
-    fn from_str(s: &str) -> Result<LeaseId, ParseError> {
-        Ok(LeaseId { id: s.to_owned() })
-    }
-}
-
-impl Display for LeaseId {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "{}", self.id)
-    }
-}
-
-impl LeaseId {
-    pub fn id(&self) -> &str {
-        &self.id
-    }
-
-    pub fn set_id(&mut self, id: &str) {
-        self.id = id.to_owned();
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn test_lease_parse() {
-        let lease = "id".parse::<LeaseId>().unwrap();
-        assert_eq!(lease.id(), "id");
-    }
-
-    #[test]
-    fn test_lease_display() {
-        let lease = "id".parse::<LeaseId>().unwrap();
-        let r = format!("{}", lease);
-        assert_eq!(r, "id");
-    }
-}
+pub type LeaseId = Uuid;

--- a/src/azure/core/lease_id.rs
+++ b/src/azure/core/lease_id.rs
@@ -8,6 +8,12 @@ pub struct LeaseId {
     id: String,
 }
 
+impl LeaseId {
+    pub fn new(s: &str) -> LeaseId {
+        LeaseId { id: s.to_owned() }
+    }
+}
+
 impl FromStr for LeaseId {
     type Err = ParseError;
     fn from_str(s: &str) -> Result<LeaseId, ParseError> {

--- a/src/azure/core/mod.rs
+++ b/src/azure/core/mod.rs
@@ -63,8 +63,6 @@ header! { (ETag, "ETag") => [String] }
 header! { (XMSRangeGetContentMD5, "x-ms-range-get-content-md5") => [bool] }
 header! { (XMSClientRequestId, "x-ms-client-request-id") => [String] }
 
-
-
 pub fn generate_authorization(h: &Headers,
                               u: &url::Url,
                               method: HTTPMethod,

--- a/src/azure/core/mod.rs
+++ b/src/azure/core/mod.rs
@@ -56,9 +56,14 @@ header! { (XMSLeaseStatus, "x-ms-lease-status") => [LeaseStatus] }
 header! { (XMSLeaseState, "x-ms-lease-state") => [LeaseState] }
 header! { (XMSLeaseAction, "x-ms-lease-action") => [LeaseAction] }
 header! { (XMSLeaseDuration, "x-ms-lease-duration") => [LeaseDuration] }
+header! { (XMSLeaseDurationSeconds, "x-ms-lease-duration") => [u32] }
+header! { (XMSLeaseBreakPeriod, "x-ms-lease-break-period") => [u32] }
+header! { (XMSProposedLeaseId, "x-ms-proposed-lease-id") => [LeaseId] }
 header! { (ETag, "ETag") => [String] }
 header! { (XMSRangeGetContentMD5, "x-ms-range-get-content-md5") => [bool] }
 header! { (XMSClientRequestId, "x-ms-client-request-id") => [String] }
+
+
 
 pub fn generate_authorization(h: &Headers,
                               u: &url::Url,

--- a/src/azure/core/mod.rs
+++ b/src/azure/core/mod.rs
@@ -20,7 +20,7 @@ use chrono;
 
 use std::io::Read;
 
-use azure::storage::{LeaseStatus, LeaseState, LeaseDuration};
+use azure::core::lease::{LeaseId, LeaseStatus, LeaseState, LeaseDuration, LeaseAction};
 
 #[macro_use]
 pub mod errors;
@@ -28,7 +28,7 @@ pub mod parsing;
 #[macro_use]
 pub mod enumerations;
 pub mod incompletevector;
-pub mod lease_id;
+pub mod lease;
 
 pub mod range;
 pub mod ba512_range;
@@ -51,9 +51,10 @@ header! { (IfMatch, "If-Match") => [String] }
 header! { (IfNoneMatch, "If-None-Match") => [String] }
 header! { (Range, "Range") => [String] }
 header! { (XMSRange, "x-ms-range") => [range::Range] }
-header! { (XMSLeaseId, "x-ms-lease-id") => [lease_id::LeaseId] }
+header! { (XMSLeaseId, "x-ms-lease-id") => [LeaseId] }
 header! { (XMSLeaseStatus, "x-ms-lease-status") => [LeaseStatus] }
 header! { (XMSLeaseState, "x-ms-lease-state") => [LeaseState] }
+header! { (XMSLeaseAction, "x-ms-lease-action") => [LeaseAction] }
 header! { (XMSLeaseDuration, "x-ms-lease-duration") => [LeaseDuration] }
 header! { (ETag, "ETag") => [String] }
 header! { (XMSRangeGetContentMD5, "x-ms-range-get-content-md5") => [bool] }

--- a/src/azure/storage/blob/lease_blob_options.rs
+++ b/src/azure/storage/blob/lease_blob_options.rs
@@ -1,22 +1,12 @@
+use azure::core::lease_id::LeaseId;
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct LeaseBlobOptions {
-    pub max_results: u32,
-    pub include_snapshots: bool,
-    pub include_metadata: bool,
-    pub include_uncommittedblobs: bool,
-    pub include_copy: bool,
-    pub next_marker: Option<String>,
-    pub prefix: Option<String>,
+    pub lease_id: Option<LeaseId>,
     pub timeout: Option<u64>,
 }
 
 pub const LEASE_BLOB_OPTIONS_DEFAULT: LeaseBlobOptions = LeaseBlobOptions {
-    max_results: 5000,
-    include_snapshots: false,
-    include_metadata: false,
-    include_uncommittedblobs: false,
-    include_copy: false,
-    next_marker: None,
-    prefix: None,
+    lease_id: None,
     timeout: None,
 };

--- a/src/azure/storage/blob/lease_blob_options.rs
+++ b/src/azure/storage/blob/lease_blob_options.rs
@@ -1,0 +1,22 @@
+#[derive(Debug, Clone, PartialEq)]
+pub struct LeaseBlobOptions {
+    pub max_results: u32,
+    pub include_snapshots: bool,
+    pub include_metadata: bool,
+    pub include_uncommittedblobs: bool,
+    pub include_copy: bool,
+    pub next_marker: Option<String>,
+    pub prefix: Option<String>,
+    pub timeout: Option<u64>,
+}
+
+pub const LEASE_BLOB_OPTIONS_DEFAULT: LeaseBlobOptions = LeaseBlobOptions {
+    max_results: 5000,
+    include_snapshots: false,
+    include_metadata: false,
+    include_uncommittedblobs: false,
+    include_copy: false,
+    next_marker: None,
+    prefix: None,
+    timeout: None,
+};

--- a/src/azure/storage/blob/lease_blob_options.rs
+++ b/src/azure/storage/blob/lease_blob_options.rs
@@ -1,4 +1,4 @@
-use azure::core::lease_id::LeaseId;
+use azure::core::lease::LeaseId;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct LeaseBlobOptions {

--- a/src/azure/storage/blob/lease_blob_options.rs
+++ b/src/azure/storage/blob/lease_blob_options.rs
@@ -4,9 +4,17 @@ use azure::core::lease::LeaseId;
 pub struct LeaseBlobOptions {
     pub lease_id: Option<LeaseId>,
     pub timeout: Option<u64>,
+    pub lease_break_period: Option<u32>,
+    pub lease_duration: Option<u32>,
+    pub proposed_lease_id: Option<LeaseId>,
+    pub request_id: Option<String>,
 }
 
 pub const LEASE_BLOB_OPTIONS_DEFAULT: LeaseBlobOptions = LeaseBlobOptions {
     lease_id: None,
     timeout: None,
+    lease_break_period: None,
+    lease_duration: None,
+    proposed_lease_id: None,
+    request_id: None,
 };

--- a/src/azure/storage/blob/mod.rs
+++ b/src/azure/storage/blob/mod.rs
@@ -16,13 +16,13 @@ pub use self::lease_blob_options::{LeaseBlobOptions, LEASE_BLOB_OPTIONS_DEFAULT}
 use chrono::datetime::DateTime;
 use chrono::UTC;
 
-use azure::storage::{LeaseStatus, LeaseState, LeaseDuration};
+use azure::core::lease::{LeaseId, LeaseStatus, LeaseState, LeaseDuration};
 use azure::storage::client::Client;
 
 use azure::core;
 use azure::core::{XMSRange, ContentMD5, XMSLeaseStatus, XMSLeaseDuration, XMSLeaseState,
                   XMSLeaseId, XMSRangeGetContentMD5, XMSClientRequestId};
-use azure::core::lease_id::LeaseId;
+
 use azure::core::parsing::{cast_must, cast_optional, from_azure_time, traverse};
 
 use xml::Element;
@@ -521,6 +521,8 @@ impl Blob {
         if let Some(ref lease_id) = lbo.lease_id {
             headers.set(XMSLeaseId(lease_id.to_owned()));
         }
+
+
 
         Ok(LeaseId::new(&"test"))
     }

--- a/src/azure/storage/blob/mod.rs
+++ b/src/azure/storage/blob/mod.rs
@@ -10,6 +10,9 @@ pub use self::put_block_options::{PutBlockOptions, PUT_BLOCK_OPTIONS_DEFAULT};
 mod put_page_options;
 pub use self::put_page_options::{PutPageOptions, PUT_PAGE_OPTIONS_DEFAULT};
 
+mod lease_blob_options;
+pub use self::lease_blob_options::{LeaseBlobOptions, LEASE_BLOB_OPTIONS_DEFAULT};
+
 use chrono::datetime::DateTime;
 use chrono::UTC;
 
@@ -501,6 +504,19 @@ impl Blob {
         try!(core::errors::check_status(&mut resp, StatusCode::Created));
 
         Ok(())
+    }
+
+    pub fn lease(&self, c: &Client, lbo: &LeaseBlobOptions) -> Result<LeaseId, AzureError> {
+        let mut uri = format!("{}://{}.blob.core.windows.net/{}/{}?comp=lease",
+                              c.auth_scheme(),
+                              c.account(),
+                              self.container_name,
+                              self.name);
+        if let Some(ref timeout) = lbo.timeout {
+            uri = format!("{}&timeout={}", uri, timeout);
+        }
+
+        Ok("todo".parse::<LeaseId>().unwrap())
     }
 
     pub fn put_page(&self,

--- a/src/azure/storage/blob/mod.rs
+++ b/src/azure/storage/blob/mod.rs
@@ -516,7 +516,13 @@ impl Blob {
             uri = format!("{}&timeout={}", uri, timeout);
         }
 
-        Ok("todo".parse::<LeaseId>().unwrap())
+        let mut headers = Headers::new();
+
+        if let Some(ref lease_id) = lbo.lease_id {
+            headers.set(XMSLeaseId(lease_id.to_owned()));
+        }
+
+        Ok(LeaseId::new(&"test"))
     }
 
     pub fn put_page(&self,

--- a/src/azure/storage/blob/put_block_options.rs
+++ b/src/azure/storage/blob/put_block_options.rs
@@ -1,4 +1,4 @@
-use azure::core::lease_id::LeaseId;
+use azure::core::lease::LeaseId;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct PutBlockOptions {

--- a/src/azure/storage/blob/put_options.rs
+++ b/src/azure/storage/blob/put_options.rs
@@ -1,4 +1,4 @@
-use azure::core::lease_id::LeaseId;
+use azure::core::lease::LeaseId;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct PutOptions {

--- a/src/azure/storage/blob/put_page_options.rs
+++ b/src/azure/storage/blob/put_page_options.rs
@@ -1,4 +1,4 @@
-use azure::core::lease_id::LeaseId;
+use azure::core::lease::LeaseId;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct PutPageOptions {

--- a/src/azure/storage/container/mod.rs
+++ b/src/azure/storage/container/mod.rs
@@ -117,6 +117,9 @@ impl Container {
         Ok(())
     }
 
+    // TODO
+    // pub fn get_acl(c : &Client, gao : &GetAclOptions)
+
     pub fn list(c: &Client,
                 lco: &ListContainerOptions)
                 -> Result<IncompleteVector<Container>, core::errors::AzureError> {

--- a/src/azure/storage/container/mod.rs
+++ b/src/azure/storage/container/mod.rs
@@ -7,7 +7,7 @@ use azure::core::enumerations;
 use azure::core::parsing::{traverse, cast_must, cast_optional};
 use azure::core::incompletevector::IncompleteVector;
 
-use azure::storage::{LeaseStatus, LeaseState, LeaseDuration};
+use azure::core::lease::{LeaseStatus, LeaseState, LeaseDuration};
 use azure::storage::client::Client;
 
 use hyper::header::Headers;

--- a/src/azure/storage/mod.rs
+++ b/src/azure/storage/mod.rs
@@ -1,28 +1,3 @@
 pub mod client;
 pub mod container;
 pub mod blob;
-
-use std::fmt;
-use std::str::FromStr;
-use azure::core::enumerations;
-
-use azure::core::errors::TraversingError;
-use azure::core::parsing::FromStringOptional;
-
-create_enum!(LeaseStatus,
-                            (Locked,        "locked"),
-                            (Unlocked,      "unlocked")
-);
-
-create_enum!(LeaseState,
-                            (Available,     "available"),
-                            (Leased,        "leased"),
-                            (Expired,       "expired"),
-                            (Breaking,      "breaking"),
-                            (Broken,        "broken")
-);
-
-create_enum!(LeaseDuration,
-                            (Infinite,      "infinite"),
-                            (Fixed,         "fixed")
-);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,8 @@ extern crate url;
 extern crate crypto;
 extern crate rustc_serialize as serialize;
 extern crate xml;
+extern crate uuid;
+
 #[macro_use]
 extern crate mime;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ extern crate log;
 extern crate env_logger;
 
 
-use azure::storage::{LeaseState, LeaseStatus};
+use azure::core::lease::{LeaseState, LeaseStatus};
 use azure::storage::client::Client;
 use azure::storage::blob::{Blob, BlobType, ListBlobOptions, LIST_BLOB_OPTIONS_DEFAULT,
                            PUT_OPTIONS_DEFAULT, PUT_BLOCK_OPTIONS_DEFAULT,


### PR DESCRIPTION
## [0.1.1](https://github.com/MindFlavor/AzureSDKForRust/releases/tag/0.0.7) (2016-01-18)

**Implemented features:**
* Lease blob (https://msdn.microsoft.com/library/azure/ee691972.aspx).

**Refactoring:**
* Renamed ```azure::core::lease_id``` module in ```azure::core::lease```.
* Moved lease enumerations in ```azure::core::lease``` module.

**Bugfixes:**
* Added the non-doc option for the bin test file:
```rust
[[bin]]
name = "main"
doc = false
```