### PR TITLE
Added Send Event to Event Hub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 git# Change Log
 
-## [0.1.3](https://github.com/MindFlavor/AzureSDKForRust/releases/tag/0.0.7) (yet-to-publish)
+## [0.1.3](https://github.com/MindFlavor/AzureSDKForRust/releases/tag/0.1.3) (yet-to-publish)
 
 **Implemented features:**
+* Added Event Hub Send Event REST API implementation (as for [https://msdn.microsoft.com/en-us/library/azure/dn790664.aspx](https://msdn.microsoft.com/en-us/library/azure/dn790664.aspx)).
 
 **Refactoring:**
 * Corrected  ```azure::core::errors::AzureError``` to include the ``std::io::Error`` and ```xml::BuilderError``` instead of their ```to_string()``` result.
@@ -10,7 +11,7 @@ git# Change Log
 
 **Bugfixes:**
 
-## [0.1.2](https://github.com/MindFlavor/AzureSDKForRust/releases/tag/0.0.7) (2016-01-18)
+## [0.1.2](https://github.com/MindFlavor/AzureSDKForRust/releases/tag/0.1.2) (2016-01-18)
 
 **Bugfixes:**
 * Added ```std::ops::DerefMut``` trait to ```azure::core::incompletevector::IncompleteVector```.
@@ -20,7 +21,7 @@ git# Change Log
 * Renamed ```azure::core::ba512_range::BA512Range::len()``` function in ```azure::core::ba512_range::BA512Range::size()``` for better linting (len requires is_empty
   and was therefore misleading).
 
-## [0.1.1](https://github.com/MindFlavor/AzureSDKForRust/releases/tag/0.0.7) (2016-01-18)
+## [0.1.1](https://github.com/MindFlavor/AzureSDKForRust/releases/tag/0.1.1) (2016-01-18)
 
 **Implemented features:**
 * Lease blob (https://msdn.microsoft.com/library/azure/ee691972.aspx).
@@ -37,7 +38,7 @@ name = "main"
 doc = false
 ```
 
-## [0.1.0](https://github.com/MindFlavor/AzureSDKForRust/releases/tag/0.0.8) (2015-01-16)
+## [0.1.0](https://github.com/MindFlavor/AzureSDKForRust/releases/tag/0.1.0) (2015-01-16)
 
 **Implemented features:**
 * Added crate exports in ```lib.rs```.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
 git# Change Log
+
+## [0.1.3](https://github.com/MindFlavor/AzureSDKForRust/releases/tag/0.0.7) (yet-to-publish)
+
+**Implemented features:**
+
+**Refactoring:**
+* Corrected  ```azure::core::errors::AzureError``` to include the ``std::io::Error`` and ```xml::BuilderError``` instead of their ```to_string()``` result.
+
+**Bugfixes:**
+
 ## [0.1.2](https://github.com/MindFlavor/AzureSDKForRust/releases/tag/0.0.7) (2016-01-18)
 
 **Bugfixes:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ git# Change Log
 
 **Refactoring:**
 * Corrected  ```azure::core::errors::AzureError``` to include the ``std::io::Error`` and ```xml::BuilderError``` instead of their ```to_string()``` result.
+* Changed ```UnexpectedResult``` enum of ```azure::core::errors::AzureError``` to ```UnexpectedHTTPResult``` which holds an instance of  ```azure::core::errors::UnexpectedHTTPResult``` instead of a tuple for better field description.
 
 **Bugfixes:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [0.1.3](https://github.com/MindFlavor/AzureSDKForRust/releases/tag/0.1.3) (yet-to-publish)
+## [0.1.3](https://github.com/MindFlavor/AzureSDKForRust/releases/tag/0.1.3) (2016-02-05)
 
 **Implemented features:**
 * Added Event Hub Send Event REST API implementation (as for [https://msdn.microsoft.com/en-us/library/azure/dn790664.aspx](https://msdn.microsoft.com/en-us/library/azure/dn790664.aspx)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,3 @@
-git# Change Log
-
 ## [0.1.3](https://github.com/MindFlavor/AzureSDKForRust/releases/tag/0.1.3) (yet-to-publish)
 
 **Implemented features:**
@@ -8,8 +6,6 @@ git# Change Log
 **Refactoring:**
 * Corrected  ```azure::core::errors::AzureError``` to include the ``std::io::Error`` and ```xml::BuilderError``` instead of their ```to_string()``` result.
 * Changed ```UnexpectedResult``` enum of ```azure::core::errors::AzureError``` to ```UnexpectedHTTPResult``` which holds an instance of  ```azure::core::errors::UnexpectedHTTPResult``` instead of a tuple for better field description.
-
-**Bugfixes:**
 
 ## [0.1.2](https://github.com/MindFlavor/AzureSDKForRust/releases/tag/0.1.2) (2016-01-18)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "azure_sdk_for_rust"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "RustyXML 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -10,7 +10,7 @@ dependencies = [
  "mime 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -58,7 +58,7 @@ dependencies = [
  "openssl 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -118,7 +118,7 @@ dependencies = [
  "traitobject 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -185,7 +185,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -312,7 +312,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "0.6.7"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -364,12 +364,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "url"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-bidi 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,14 +3,16 @@ name = "azure_sdk_for_rust"
 version = "0.1.3"
 dependencies = [
  "RustyXML 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clippy 0.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -30,7 +32,7 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "memchr 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -43,7 +45,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "chrono"
-version = "0.2.17"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -51,14 +53,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "clippy"
+version = "0.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "semver 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cookie"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "openssl 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -67,7 +78,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.48 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -111,14 +122,14 @@ dependencies = [
  "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "solicit 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "traitobject 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -147,7 +158,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -163,7 +174,7 @@ name = "log"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -176,7 +187,7 @@ name = "memchr"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -185,17 +196,18 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "nom"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "num"
 version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "rand 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "num_cpus"
@@ -203,30 +215,30 @@ version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "openssl"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "gcc 0.3.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys-extras 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys-extras 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gdi32-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "libressl-pnacl-sys 2.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "user32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -234,12 +246,12 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys-extras"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.3.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -261,16 +273,16 @@ version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "advapi32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex"
-version = "0.1.47"
+version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aho-corasick 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -299,7 +311,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustc_version"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -311,8 +323,16 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "semver"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nom 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "serde"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -341,7 +361,7 @@ version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -360,7 +380,7 @@ name = "unicase"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rustc_version 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -378,7 +398,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "url"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ dependencies = [
  "mime 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 0.5.2 (git+https://github.com/servo/rust-url)",
+ "url 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -361,16 +361,6 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rustc_version 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "url"
-version = "0.5.2"
-source = "git+https://github.com/servo/rust-url#9d88f176633de07dcb0a43c1fedb9711d98021f4"
-dependencies = [
- "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,10 +4,9 @@ version = "0.1.2"
 dependencies = [
  "RustyXML 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "clippy 0.0.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -52,15 +51,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clippy"
-version = "0.0.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "semver 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-normalization 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "cookie"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,8 +66,8 @@ name = "env_logger"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "log 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.47 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -102,7 +92,7 @@ name = "hpack"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "log 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -118,7 +108,7 @@ dependencies = [
  "cookie 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "language-tags 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -170,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -194,14 +184,9 @@ name = "mime"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "log 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "nom"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "num"
@@ -282,7 +267,7 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -326,14 +311,6 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "semver"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "nom 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "serde"
 version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,7 +324,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hpack 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -385,11 +362,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rustc_version 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "url"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,6 @@ version = "0.1.3"
 dependencies = [
  "RustyXML 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "clippy 0.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -50,15 +49,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "clippy"
-version = "0.0.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "semver 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-normalization 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -200,11 +190,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nom"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "num"
 version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,14 +306,6 @@ dependencies = [
 name = "semver"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "semver"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "nom 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ uuid = "*"
 time = "*"
 url = "*"
 
-clippy="*"
+# clippy="*"
 
 [dependencies.hyper]
 version = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,19 +13,19 @@ name = "main"
 doc = false
 
 [dependencies]
-chrono = "*"
-rust-crypto = "*"
-rustc-serialize = "*"
-RustyXML = "*"
-mime = "*"
-log = "*"
-env_logger = "*"
-uuid = "*"
-time = "*"
-url = "*"
+chrono = "0.2.19"
+rust-crypto = "0.2.34"
+rustc-serialize = "0.3.16"
+RustyXML = "0.1.1"
+mime = "0.1.1"
+log = "0.3.5"
+env_logger = "0.3.2"
+uuid = "0.1.18"
+time = "0.1.34"
+url = "0.5.4"
 
 # clippy="*"
 
 [dependencies.hyper]
-version = "*"
+version = "0.7.2"
 default-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.2"
 description = "Rust wrappers around Microsoft Azure REST APIs"
 readme = "README.md"
 authors = ["Francesco Cogno <francesco.cogno@outlook.com>"]
-license = "Apache v.2"
+license = "Apache-2.0"
 repository = "https://github.com/MindFlavor/AzureSDKForRust"
 
 [[bin]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_sdk_for_rust"
-version = "0.1.2"
+version = "0.1.3"
 description = "Rust wrappers around Microsoft Azure REST APIs"
 readme = "README.md"
 authors = ["Francesco Cogno <francesco.cogno@outlook.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,9 @@ readme = "README.md"
 authors = ["Francesco Cogno <francesco.cogno@outlook.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/MindFlavor/AzureSDKForRust"
+documentation = "http://mindflavor.github.io/AzureSDKForRust/azure_sdk_for_rust/index.html"
+
+http://mindflavor.github.io/AzureSDKForRust/azure_sdk_for_rust/index.html
 
 [[bin]]
 name = "main"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,18 +1,22 @@
 [package]
 name = "azure_sdk_for_rust"
 version = "0.1.2"
+description = "Rust wrappers around Microsoft Azure REST APIs"
+readme = "README.md"
 authors = ["Francesco Cogno <francesco.cogno@outlook.com>"]
+license = "Apache v.2"
+repository = "https://github.com/MindFlavor/AzureSDKForRust"
 
 [[bin]]
 name = "main"
 doc = false
 
 [dependencies]
-chrono = "*"
+chrono = "^0.2"
 rust-crypto = "^0.2"
-rustc-serialize = "*"
-RustyXML = "*"
-mime = "*"
+rustc-serialize = "^0.3"
+RustyXML = "^0.1"
+mime = "^0.1"
 log = "0.3"
 env_logger = "0.3"
 uuid = "^0.1"
@@ -20,7 +24,7 @@ uuid = "^0.1"
 # clippy="*"
 
 [dependencies.hyper]
-version = "*"
+version = "^0.7"
 default-features = true
 
 [dependencies.url]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,6 @@ license = "Apache-2.0"
 repository = "https://github.com/MindFlavor/AzureSDKForRust"
 documentation = "http://mindflavor.github.io/AzureSDKForRust/azure_sdk_for_rust/index.html"
 
-http://mindflavor.github.io/AzureSDKForRust/azure_sdk_for_rust/index.html
-
 [[bin]]
 name = "main"
 doc = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,8 @@ uuid = "^0.1"
 
 # clippy="*"
 
+url = "0.5.2"
+
 [dependencies.hyper]
 version = "^0.7"
 default-features = true
-
-[dependencies.url]
-git = "https://github.com/servo/rust-url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,19 +13,19 @@ name = "main"
 doc = false
 
 [dependencies]
-chrono = "^0.2"
-rust-crypto = "^0.2"
-rustc-serialize = "^0.3"
-RustyXML = "^0.1"
-mime = "^0.1"
-log = "0.3"
-env_logger = "0.3"
-uuid = "^0.1"
+chrono = "*"
+rust-crypto = "*"
+rustc-serialize = "*"
+RustyXML = "*"
+mime = "*"
+log = "*"
+env_logger = "*"
+uuid = "*"
+time = "*"
+url = "*"
 
-# clippy="*"
-
-url = "0.5.2"
+clippy="*"
 
 [dependencies.hyper]
-version = "^0.7"
+version = "*"
 default-features = true

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ fn main() {
 
 ## State of the art
 Right now very few methods have been implemented but the key framework is in place (authentication, enumerations, parsing and so on). If you want to contribute please do!
-Methods are added daily so please check the [CHANGELOG.md](AzureSDKForRust/CHANGELOG.md) for updates on the progress.
+Methods are added daily so please check the [CHANGELOG.md](CHANGELOG.md) for updates on the progress.
 Also note that the project is in early stages so the APIs are bound to change at any moment. I will strive to keep things steady but since I'm new to Rust I'm sure I'll have to correct some serious mistake before too long :smile:.
 I generally build for the latest nightly and leave to Travis to check the retrocompatibility.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/MindFlavor/AzureSDKForRust.svg?branch=master)](https://travis-ci.org/MindFlavor/AzureSDKForRust) [![Coverage Status](https://coveralls.io/repos/MindFlavor/AzureSDKForRust/badge.svg?branch=master&service=github)](https://coveralls.io/github/MindFlavor/AzureSDKForRust?branch=master) [![experimental](http://badges.github.io/stability-badges/dist/experimental.svg)](http://github.com/badges/stability-badges)
 
 ## Introduction
-Microsoft Azure expose its technologies via REST API. These APIs are easily consumable from any language (good) but are weakly typed. With this library and its related (as soon as I figure out how to make it) crate you can exploit the power of Microsoft Azure from Rust in a idiomatic way.    
+Microsoft Azure expose its technologies via REST API. These APIs are easily consumable from any language (good) but are weakly typed. With this library and its related [crate](https://crates.io/crates/azure_sdk_for_rust/) you can exploit the power of Microsoft Azure from Rust in a idiomatic way.    
 
 > **NOTE:** This repository is under heavy ongoing development and
 is likely to break over time. I currently do not have any releases

--- a/README.md
+++ b/README.md
@@ -108,7 +108,9 @@ fn main() {
 
 ## State of the art
 Right now very few methods have been implemented but the key framework is in place (authentication, enumerations, parsing and so on). If you want to contribute please do!
+Methods are added daily so please check the [CHANGELOG.md](AzureSDKForRust/CHANGELOG.md) for updates on the progress.
 Also note that the project is in early stages so the APIs are bound to change at any moment. I will strive to keep things steady but since I'm new to Rust I'm sure I'll have to correct some serious mistake before too long :smile:.
+I generally build for the latest nightly and leave to Travis to check the retrocompatibility.
 
 ## Contributing
 If you want to contribute please do! No formality required! :wink:
@@ -134,6 +136,13 @@ If you want to contribute please do! No formality required! :wink:
 |Clear blob page|[https://msdn.microsoft.com/en-us/library/azure/dd179451.aspx](https://msdn.microsoft.com/en-us/library/azure/dd179451.aspx)|
 |Put block|[https://msdn.microsoft.com/en-us/library/azure/dd135726.aspx](https://msdn.microsoft.com/en-us/library/azure/dd135726.aspx)|
 |Lease blob|[https://msdn.microsoft.com/library/azure/ee691972.aspx](https://msdn.microsoft.com/library/azure/ee691972.aspx)|
+
+#### Event Hubs
+
+|Method | URL |
+| ----  | --- |
+|Send Event|[https://msdn.microsoft.com/en-us/library/azure/dn790664.aspx](https://msdn.microsoft.com/en-us/library/azure/dn790664.aspx)|
+
 
 ## License
 This project is published under [The MIT License (MIT)](LICENSE).

--- a/src/azure/core/errors.rs
+++ b/src/azure/core/errors.rs
@@ -6,6 +6,7 @@ use xml::BuilderError as XMLError;
 use std::io::Read;
 use std::num;
 // use xml;
+use url::ParseError as URLParseError;
 use azure::core::enumerations::ParsingError;
 use azure::core::range::ParseError;
 
@@ -39,6 +40,7 @@ pub enum AzureError {
     GenericError,
     ParsingError(ParsingError),
     InputParametersError(String),
+    URLParseError(URLParseError),
 }
 
 #[derive(Debug)]
@@ -51,6 +53,12 @@ pub enum TraversingError {
     ParseIntError(num::ParseIntError),
     GenericParseError(String),
     ParsingError(ParsingError),
+}
+
+impl From<URLParseError> for AzureError {
+    fn from(upe: URLParseError) -> AzureError {
+        AzureError::URLParseError(upe)
+    }
 }
 
 impl From<ParseError> for AzureError {

--- a/src/azure/core/incompletevector.rs
+++ b/src/azure/core/incompletevector.rs
@@ -41,6 +41,7 @@ impl<T> Deref for IncompleteVector<T> {
     }
 }
 
+#[cfg(test)]
 mod test {
     #[allow(unused_imports)]
     use super::IncompleteVector;

--- a/src/azure/core/lease.rs
+++ b/src/azure/core/lease.rs
@@ -5,30 +5,22 @@ use azure::core::errors::TraversingError;
 use azure::core::parsing::FromStringOptional;
 use uuid::Uuid;
 
-create_enum!(LeaseStatus,
-                            (Locked,        "locked"),
-                            (Unlocked,      "unlocked")
-);
+create_enum!(LeaseStatus, (Locked, "locked"), (Unlocked, "unlocked"));
 
 create_enum!(LeaseState,
-                            (Available,     "available"),
-                            (Leased,        "leased"),
-                            (Expired,       "expired"),
-                            (Breaking,      "breaking"),
-                            (Broken,        "broken")
-);
+             (Available, "available"),
+             (Leased, "leased"),
+             (Expired, "expired"),
+             (Breaking, "breaking"),
+             (Broken, "broken"));
 
-create_enum!(LeaseDuration,
-                            (Infinite,      "infinite"),
-                            (Fixed,         "fixed")
-);
+create_enum!(LeaseDuration, (Infinite, "infinite"), (Fixed, "fixed"));
 
 create_enum!(LeaseAction,
-                            (Acquire,      "acquire"),
-                            (Renew,         "renew "),
-                            (Change,        "change"),
-                            (Release,        "release "),
-                            (Break,         "break")
-);
+             (Acquire, "acquire"),
+             (Renew, "renew "),
+             (Change, "change"),
+             (Release, "release "),
+             (Break, "break"));
 
 pub type LeaseId = Uuid;

--- a/src/azure/core/mod.rs
+++ b/src/azure/core/mod.rs
@@ -151,8 +151,10 @@ pub fn string_to_sign(h: &Headers, u: &url::Url, method: HTTPMethod) -> String {
     // \n    /*If-None-Match*/
     // \n    /*If-Unmodified-Since*/
     // \n    /*Range*/
-    // x-ms-date:Sun, 11 Oct 2009 21:49:13 GMT\nx-ms-version:2009-09-19\n    /*CanonicalizedHeaders*/
-    // /myaccount /mycontainer\ncomp:metadata\nrestype:container\ntimeout:20    /*CanonicalizedResource*/
+    // x-ms-date:Sun, 11 Oct 2009 21:49:13 GMT\nx-ms-version:2009-09-19\n
+    //                                  /*CanonicalizedHeaders*/
+    // /myaccount /mycontainer\ncomp:metadata\nrestype:container\ntimeout:20
+    //                                  /*CanonicalizedResource*/
     //
     //
 

--- a/src/azure/mod.rs
+++ b/src/azure/mod.rs
@@ -1,3 +1,4 @@
 #[macro_use]
 pub mod core;
 pub mod storage;
+pub mod service_bus;

--- a/src/azure/service_bus/event_hub/client.rs
+++ b/src/azure/service_bus/event_hub/client.rs
@@ -41,7 +41,7 @@ impl Client {
     }
 }
 
-
+#[cfg(test)]
 mod test {
     #[allow(unused_imports)]
     use super::Client;
@@ -49,5 +49,20 @@ mod test {
     #[test]
     pub fn client_ctor() {
         Client::new("namespace", "event_hub", "policy", "key");
+    }
+
+    #[test]
+    pub fn client_enc() {
+        use crypto::mac::Mac;
+        use serialize::base64::{STANDARD, ToBase64};
+
+        let str_to_sign = "This must be secret!";
+
+        let mut c = Client::new("namespace", "event_hub", "policy", "key");
+
+        c.hmac.input(str_to_sign.as_bytes());
+        let sig = c.hmac.result().code().to_base64(STANDARD);
+
+        assert_eq!(sig, "2UNXaoPpeJBAhh6qxmTqXyNzTpOflGO6IhxegeUQBcU=");
     }
 }

--- a/src/azure/service_bus/event_hub/client.rs
+++ b/src/azure/service_bus/event_hub/client.rs
@@ -1,0 +1,22 @@
+use azure::service_bus::event_hub::submit_event;
+
+pub struct Client {
+    pub namespace: String,
+    pub event_hub: String,
+    pub policy_name: String,
+    pub key: String,
+}
+
+impl Client {
+    pub fn new(namespace: &str,
+        event_hub: &str,
+        policy_name: &str,
+        key: &str) -> Client {
+            Client {
+                namespace : namespace.to_owned(),
+                event_hub : event_hub.to_owned(),
+                policy_name : policy_name.to_owned(),
+                key : key.to_owned()
+            }
+    }
+}

--- a/src/azure/service_bus/event_hub/client.rs
+++ b/src/azure/service_bus/event_hub/client.rs
@@ -1,22 +1,53 @@
-use azure::service_bus::event_hub::submit_event;
+use azure::service_bus::event_hub::send_event;
+use azure::core::errors::AzureError;
+
+use time::Duration;
+use std::io::Read;
+
+use crypto::sha2::Sha256;
+use crypto::hmac::Hmac;
 
 pub struct Client {
-    pub namespace: String,
-    pub event_hub: String,
-    pub policy_name: String,
-    pub key: String,
+    namespace: String,
+    event_hub: String,
+    policy_name: String,
+    hmac: Hmac<Sha256>,
 }
 
 impl Client {
-    pub fn new(namespace: &str,
-        event_hub: &str,
-        policy_name: &str,
-        key: &str) -> Client {
-            Client {
-                namespace : namespace.to_owned(),
-                event_hub : event_hub.to_owned(),
-                policy_name : policy_name.to_owned(),
-                key : key.to_owned()
-            }
+    pub fn new(namespace: &str, event_hub: &str, policy_name: &str, key: &str) -> Client {
+        let mut v_hmac_key: Vec<u8> = Vec::new();
+        v_hmac_key.extend(key.as_bytes());
+        let hmac = Hmac::new(Sha256::new(), &v_hmac_key);
+
+        Client {
+            namespace: namespace.to_owned(),
+            event_hub: event_hub.to_owned(),
+            policy_name: policy_name.to_owned(),
+            hmac: hmac,
+        }
+    }
+
+    pub fn send_event(&mut self,
+                      event_body: (&mut Read, u64),
+                      duration: Duration)
+                      -> Result<(), AzureError> {
+        send_event(&self.namespace,
+                   &self.event_hub,
+                   &self.policy_name,
+                   &mut self.hmac,
+                   event_body,
+                   duration)
+    }
+}
+
+
+mod test {
+    #[allow(unused_imports)]
+    use super::Client;
+
+    #[test]
+    pub fn client_ctor() {
+        Client::new("namespace", "event_hub", "policy", "key");
     }
 }

--- a/src/azure/service_bus/event_hub/mod.rs
+++ b/src/azure/service_bus/event_hub/mod.rs
@@ -1,0 +1,93 @@
+use azure::core::errors::{AzureError, UnexpectedHTTPResult};
+
+use hyper;
+use hyper::header::{Headers, ContentLength};
+use hyper::status::StatusCode;
+
+use chrono;
+use time::Duration;
+
+use std::ops::Add;
+use serialize::base64::{STANDARD, ToBase64};
+
+use url::percent_encoding::{utf8_percent_encode, HTTP_VALUE_ENCODE_SET, FORM_URLENCODED_ENCODE_SET};
+
+use crypto::sha2::Sha256;
+use crypto::hmac::Hmac;
+use crypto::mac::Mac;
+
+use url::Url;
+use std::io::Read;
+
+header! { (Authorization, "Authorization") => [String] }
+
+pub fn submit_event(namespace: &str,
+                    event_hub: &str,
+                    policy_name: &str,
+                    key: &str,
+                    event_body: (&mut Read, u64),
+                    duration: Duration)
+                    -> Result<(), AzureError> {
+
+    // prepare the url to call
+    let url = format!("https://{}.servicebus.windows.net/{}/messages",
+                      namespace,
+                      event_hub);
+    let url = try!(Url::parse(&url));
+    debug!("url == {:?}", url);
+
+    // create content
+
+    // generate sas signature based on key name, key value, url and duration.
+    let sas = generate_signature(&policy_name, &key, &url.to_string(), duration);
+    debug!("sas == {}", sas);
+
+    // add required headers (in this case just the Authorization and Content-Length).
+    let client = hyper::client::Client::new();
+    let mut headers = Headers::new();
+    headers.set(Authorization(sas));
+    headers.set(ContentLength(event_body.1));
+
+
+    let body = hyper::client::Body::SizedBody(event_body.0, event_body.1);
+
+    // Post the request along with the headers and the body.
+    let mut response = try!(client.post(url).body(body).headers(headers).send());
+    info!("response.status == {}", response.status);
+    debug!("response.headers == {:?}", response.headers);
+
+    if response.status != StatusCode::Created {
+        debug!("response status unexpected, returning Err");
+        let mut resp_s = String::new();
+        try!(response.read_to_string(&mut resp_s));
+        return Err(AzureError::UnexpectedHTTPResult(UnexpectedHTTPResult::new(StatusCode::Created, response.status, &resp_s)));
+    }
+
+    debug!("response status ok, returning Ok");
+    Ok(())
+}
+
+pub fn generate_signature(policy_name: &str, hmac_key: &str, url: &str, ttl: Duration) -> String {
+    let expiry = chrono::UTC::now().add(ttl).timestamp();
+    debug!("expiry == {:?}", expiry);
+
+    let url_encoded = utf8_percent_encode(url, HTTP_VALUE_ENCODE_SET);
+    debug!("url_encoded == {:?}", url_encoded);
+
+    let str_to_sign = format!("{}\n{}", url_encoded, expiry);
+    debug!("str_to_sign == {:?}", str_to_sign);
+
+    let mut v_hmac_key: Vec<u8> = Vec::new();
+    v_hmac_key.extend(hmac_key.as_bytes());
+    let mut hmac = Hmac::new(Sha256::new(), &v_hmac_key);
+    hmac.input(str_to_sign.as_bytes());
+    let sig = hmac.result().code().to_base64(STANDARD);
+    let sig = utf8_percent_encode(&sig, FORM_URLENCODED_ENCODE_SET);
+    debug!("sig == {:?}", sig);
+
+    format!("SharedAccessSignature sr={}&sig={}&se={}&skn={}",
+            &url_encoded,
+            sig,
+            expiry,
+            policy_name)
+}

--- a/src/azure/service_bus/event_hub/mod.rs
+++ b/src/azure/service_bus/event_hub/mod.rs
@@ -19,9 +19,12 @@ use crypto::mac::Mac;
 use url::Url;
 use std::io::Read;
 
+mod client;
+pub use self::client::Client;
+
 header! { (Authorization, "Authorization") => [String] }
 
-pub fn submit_event(namespace: &str,
+fn submit_event(namespace: &str,
                     event_hub: &str,
                     policy_name: &str,
                     key: &str,
@@ -48,7 +51,6 @@ pub fn submit_event(namespace: &str,
     headers.set(Authorization(sas));
     headers.set(ContentLength(event_body.1));
 
-
     let body = hyper::client::Body::SizedBody(event_body.0, event_body.1);
 
     // Post the request along with the headers and the body.
@@ -67,7 +69,7 @@ pub fn submit_event(namespace: &str,
     Ok(())
 }
 
-pub fn generate_signature(policy_name: &str, hmac_key: &str, url: &str, ttl: Duration) -> String {
+fn generate_signature(policy_name: &str, hmac_key: &str, url: &str, ttl: Duration) -> String {
     let expiry = chrono::UTC::now().add(ttl).timestamp();
     debug!("expiry == {:?}", expiry);
 

--- a/src/azure/service_bus/mod.rs
+++ b/src/azure/service_bus/mod.rs
@@ -1,0 +1,1 @@
+pub mod event_hub;

--- a/src/azure/storage/blob/mod.rs
+++ b/src/azure/storage/blob/mod.rs
@@ -38,8 +38,7 @@ use azure::core::ETag;
 
 use std::io::Read;
 
-use azure::core::errors::{TraversingError, AzureError, check_status, new_from_ioerror_string,
-                          new_from_xmlerror_string};
+use azure::core::errors::{TraversingError, AzureError, check_status};
 use azure::core::parsing::FromStringOptional;
 
 use azure::core::range::Range;
@@ -347,18 +346,12 @@ impl Blob {
         try!(check_status(&mut resp, StatusCode::Ok));
 
         let mut resp_s = String::new();
-        match resp.read_to_string(&mut resp_s) {
-            Ok(_) => (),
-            Err(err) => return Err(new_from_ioerror_string(err.to_string())),
-        };
+        try!(resp.read_to_string(&mut resp_s));
 
         println!("resp_s == {:?}\n\n", resp_s);
 
         let sp = &resp_s;
-        let elem: Element = match sp.parse() {
-            Ok(res) => res,
-            Err(err) => return Err(new_from_xmlerror_string(err.to_string())),
-        };
+        let elem: Element = try!(sp.parse());
 
         let next_marker = match try!(cast_optional::<String>(&elem, &["NextMarker"])) {
             Some(ref nm) if nm == "" => None,

--- a/src/azure/storage/blob/mod.rs
+++ b/src/azure/storage/blob/mod.rs
@@ -56,22 +56,17 @@ use serialize::base64::{STANDARD, ToBase64};
 use uuid::Uuid;
 
 create_enum!(BlobType,
-                            (BlockBlob,        "BlockBlob"),
-                            (PageBlob,         "PageBlob"),
-                            (AppendBlob,       "AppendBlob")
-);
+             (BlockBlob, "BlockBlob"),
+             (PageBlob, "PageBlob"),
+             (AppendBlob, "AppendBlob"));
 
 create_enum!(CopyStatus,
-                            (Pending,          "pending"),
-                            (Success,          "success"),
-                            (Aborted,          "aborted"),
-                            (Failed,           "failed")
-);
+             (Pending, "pending"),
+             (Success, "success"),
+             (Aborted, "aborted"),
+             (Failed, "failed"));
 
-create_enum!(PageWriteType,
-                            (Update,            "update"),
-                            (Clear,             "clear")
-);
+create_enum!(PageWriteType, (Update, "update"), (Clear, "clear"));
 
 header! { (XMSBlobContentLength, "x-ms-blob-content-length") => [u64] }
 header! { (XMSBlobSequenceNumber, "x-ms-blob-sequence-number") => [u64] }
@@ -262,7 +257,8 @@ impl Blob {
         };
         println!("lease_duration == {:?}", lease_duration);
 
-        // TODO: get the remaining headers (https://msdn.microsoft.com/en-us/library/azure/dd179440.aspx)
+        // TODO: get the remaining headers
+        // (https://msdn.microsoft.com/en-us/library/azure/dd179440.aspx)
 
         Ok(Blob {
             name: blob_name.to_owned(),

--- a/src/azure/storage/container/mod.rs
+++ b/src/azure/storage/container/mod.rs
@@ -29,10 +29,9 @@ use azure::core::parsing::FromStringOptional;
 header! { (XMSBlobPublicAccess, "x-ms-blob-public-access") => [PublicAccess] }
 
 create_enum!(PublicAccess,
-                            (None,          "none"),
-                            (Container,     "container"),
-                            (Blob,          "blob")
-);
+             (None, "none"),
+             (Container, "container"),
+             (Blob, "blob"));
 
 
 #[derive(Debug)]

--- a/src/azure/storage/container/mod.rs
+++ b/src/azure/storage/container/mod.rs
@@ -151,18 +151,12 @@ impl Container {
         // println!("{:?}", resp.status);
 
         let mut resp_s = String::new();
-        match resp.read_to_string(&mut resp_s) {
-            Ok(_) => (),
-            Err(err) => return Err(errors::new_from_ioerror_string(err.to_string())),
-        };
+        try!(resp.read_to_string(&mut resp_s));
 
         // println!("response == \n\n{:?}\n\n", resp_s);
 
         let sp = &resp_s;
-        let elem: Element = match sp.parse() {
-            Ok(res) => res,
-            Err(err) => return Err(errors::new_from_xmlerror_string(err.to_string())),
-        };
+        let elem: Element = try!(sp.parse()); 
 
         let mut v = Vec::new();
 

--- a/src/azure/storage/container/mod.rs
+++ b/src/azure/storage/container/mod.rs
@@ -156,7 +156,7 @@ impl Container {
         // println!("response == \n\n{:?}\n\n", resp_s);
 
         let sp = &resp_s;
-        let elem: Element = try!(sp.parse()); 
+        let elem: Element = try!(sp.parse());
 
         let mut v = Vec::new();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+// #![feature(plugin)]
+// #![plugin(clippy)]
+
 #[macro_use]
 extern crate hyper;
 extern crate chrono;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ extern crate crypto;
 extern crate rustc_serialize as serialize;
 extern crate xml;
 extern crate uuid;
+extern crate time;
 
 #[macro_use]
 extern crate mime;

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,9 @@ use azure::storage::blob::{Blob, BlobType, LIST_BLOB_OPTIONS_DEFAULT, PUT_OPTION
 use azure::storage::container::{Container, PublicAccess, LIST_CONTAINER_OPTIONS_DEFAULT};
 use azure::core::ba512_range::BA512Range;
 
+use std::fs;
+use time::Duration;
+
 // use azure::storage::container::PublicAccess;
 
 #[macro_use]
@@ -36,6 +39,7 @@ use chrono::UTC;
 
 use mime::Mime;
 
+#[allow(unused_variables)]
 fn main() {
     env_logger::init().unwrap();
 
@@ -55,13 +59,54 @@ fn main() {
 
     let client = Client::new(&azure_storage_account, &azure_storage_key, true);
 
+    let policy_name = match std::env::var("AZURE_POLICY_NAME") {
+        Ok(val) => val,
+        Err(_) => {
+            panic!("Please set AZURE_POLICY_NAME env variable first!");
+        }
+    };
+
+    let policy_key = match std::env::var("AZURE_POLICY_KEY") {
+        Ok(val) => val,
+        Err(_) => {
+            panic!("Please set AZURE_POLICY_KEY env variable first!");
+        }
+    };
+
+    let sb_namespace = match std::env::var("AZURE_SERVICE_BUS_NAMESPACE") {
+        Ok(val) => val,
+        Err(_) => {
+            panic!("Please set AZURE_SERVICE_BUS_NAMESPACE env variable first!");
+        }
+    };
+
+    let ev_name = match std::env::var("AZURE_EVENT_HUB_NAME") {
+        Ok(val) => val,
+        Err(_) => {
+            panic!("Please set AZURE_EVENT_HUB_NAME env variable first!");
+        }
+    };
+
+    let mut eh_client = azure::service_bus::event_hub::Client::new(&sb_namespace,
+                                                                   &ev_name,
+                                                                   &policy_name,
+                                                                   &policy_key);
+    // "todeleh",
+    // "write_policy",
+    // "9GIzBhQhMKg/patjrI2XS6gSGn6ju2+N40CQEYmowJ8=");
+
     // client.create_container("balocco3", PublicAccess::Blob).unwrap();
     // // println!("{:?}", new);
     //
 
     info!("Beginning tests");
 
-    lease_blob(&client);
+    for i in 0..20 {
+        info!("Sending message {}", i);
+        send_event(&mut eh_client);
+    }
+
+    // lease_blob(&client);
 
     // put_block_blob(&client);
     //
@@ -155,6 +200,19 @@ fn main() {
     // inc_a!("main");
 }
 
+#[allow(dead_code)]
+fn send_event(cli: &mut azure::service_bus::event_hub::Client) {
+    debug!("running send_event");
+    let file_name = "C:\\temp\\samplein.json";
+
+    let metadata = fs::metadata(file_name).unwrap();
+    let mut file_handle = fs::File::open(file_name).unwrap();
+
+    cli.send_event((&mut file_handle, metadata.len()), Duration::hours(1))
+       .unwrap();
+}
+
+#[allow(dead_code)]
 fn lease_blob(client: &Client) {
     println!("running lease_blob");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ extern crate rustc_serialize as serialize;
 extern crate xml;
 #[macro_use]
 extern crate mime;
+extern crate time;
 
 #[macro_use]
 extern crate log;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
 // #![feature(plugin)]
-//
 // #![plugin(clippy)]
 
 #[macro_use]


### PR DESCRIPTION
## [0.1.3](https://github.com/MindFlavor/AzureSDKForRust/releases/tag/0.1.3) (2016-02-05)

**Implemented features:**
* Added Event Hub Send Event REST API implementation (as for [https://msdn.microsoft.com/en-us/library/azure/dn790664.aspx](https://msdn.microsoft.com/en-us/library/azure/dn790664.aspx)).

**Refactoring:**
* Corrected  ```azure::core::errors::AzureError``` to include the ``std::io::Error`` and ```xml::BuilderError``` instead of their ```to_string()``` result.
* Changed ```UnexpectedResult``` enum of ```azure::core::errors::AzureError``` to ```UnexpectedHTTPResult``` which holds an instance of  ```azure::core::errors::UnexpectedHTTPResult``` instead of a tuple for better field description.