### PR TITLE
Removes Deref and AsRef impls for Database and Collection

### DIFF
--- a/examples/collection.rs
+++ b/examples/collection.rs
@@ -66,7 +66,7 @@ fn code() -> Result<(), Box<Error>> {
         // Each Cosmos' database contains so or more collections. We can enumerate them using the
         // list_collection method.
         for db in databases {
-            v.push(client.list_collections(&db).map(move |collections| {
+            v.push(client.list_collections(&db.id).map(move |collections| {
                 println!("database {} has {} collection(s)", db.id, collections.len());
 
                 for collection in collections {

--- a/examples/document00.rs
+++ b/examples/document00.rs
@@ -86,7 +86,7 @@ fn code() -> Result<(), Box<Error>> {
     // we will create it. The collection creation is more complex and
     // has many options (such as indexing and so on).
     let collection = {
-        let collections = core.run(client.list_collections(&database))?;
+        let collections = core.run(client.list_collections(&database.id))?;
 
         if let Some(collection) = collections.into_iter().find(|coll| coll.id == COLLECTION) {
             collection
@@ -115,7 +115,7 @@ fn code() -> Result<(), Box<Error>> {
             // Performance levels have price impact. Also, higher
             // performance levels force you to specify an indexing
             // strategy. Consult the documentation for more details.
-            core.run(client.create_collection(&database, 400, &coll))?
+            core.run(client.create_collection(&database.id, 400, &coll))?
         }
     };
 
@@ -136,8 +136,8 @@ fn code() -> Result<(), Box<Error>> {
     // The method create_document will return, upon success,
     // the document attributes.
     let document_attributes = core.run(client.create_document_as_entity(
-        &database,
-        &collection,
+        &database.id,
+        &collection.id,
         false,
         None,
         &PartitionKey::default(),

--- a/src/azure/cosmos/collection.rs
+++ b/src/azure/cosmos/collection.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 #[derive(Serialize, Deserialize, Debug)]
 pub enum KeyKind {
     Hash,
@@ -110,19 +108,5 @@ impl Collection {
             udfs: "".to_owned(),
             conflicts: "".to_owned(),
         }
-    }
-}
-
-impl Deref for Collection {
-    type Target = str;
-
-    fn deref(&self) -> &str {
-        &self.id
-    }
-}
-
-impl AsRef<str> for Collection {
-    fn as_ref(&self) -> &str {
-        &self.id
     }
 }

--- a/src/azure/cosmos/database.rs
+++ b/src/azure/cosmos/database.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Database {
     pub id: String,
@@ -15,18 +13,4 @@ pub struct Database {
     pub colls: String,
     #[serde(rename = "_users")]
     pub users: String,
-}
-
-impl Deref for Database {
-    type Target = str;
-
-    fn deref(&self) -> &str {
-        &self.id
-    }
-}
-
-impl AsRef<str> for Database {
-    fn as_ref(&self) -> &str {
-        &self.id
-    }
 }


### PR DESCRIPTION
Per API guidelines Deref should not be implemented on Database or Collection: https://rust-lang-nursery.github.io/api-guidelines/predictability.html#only-smart-pointers-implement-deref-and-derefmut-c-deref

Also I think AsRef<str> is misleading here as a whole struct with a number of fields is reduced to str for id. It isn't too bad to access id IMO like `db.id()` going forward.