### PR TITLE
Implemented container::break_lease

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,12 +202,16 @@ If you want to contribute please do! No formality required! :wink:. Please note 
 
 | Method           | URL                                                                                                                                                                      | Builder pattern
 | ----             | ---                                                                                                                                                                      | ---
-| Create container | [https://msdn.microsoft.com/en-us/library/azure/dd179468.aspx](https://msdn.microsoft.com/en-us/library/azure/dd179468.aspx)                                             | yes
-| List containers  | [https://msdn.microsoft.com/en-us/library/azure/dd179352.aspx](https://msdn.microsoft.com/en-us/library/azure/dd179352.aspx)                                             | yes
-| Delete container | [https://msdn.microsoft.com/en-us/library/azure/dd179408.aspx](https://msdn.microsoft.com/en-us/library/azure/dd179408.aspx)                                             | yes
+| Create container | [https://docs.microsoft.com/en-us/rest/api/storageservices/create-container](https://docs.microsoft.com/en-us/rest/api/storageservices/create-container)                 | yes
+| List containers  | [https://docs.microsoft.com/en-us/rest/api/storageservices/list-containers2](https://docs.microsoft.com/en-us/rest/api/storageservices/list-containers2)                 | yes
+| Delete container | [https://docs.microsoft.com/en-us/rest/api/storageservices/delete-container](https://docs.microsoft.com/en-us/rest/api/storageservices/delete-container)                 | yes
 | Get ACLs         | [https://docs.microsoft.com/en-us/rest/api/storageservices/get-container-acl](https://docs.microsoft.com/en-us/rest/api/storageservices/get-container-acl)               | yes
 | Set ACLs         | [https://docs.microsoft.com/en-us/rest/api/storageservices/set-container-acl](https://docs.microsoft.com/en-us/rest/api/storageservices/set-container-acl)               | yes
 | Get properties   | [https://docs.microsoft.com/en-us/rest/api/storageservices/get-container-properties](https://docs.microsoft.com/en-us/rest/api/storageservices/get-container-properties) | yes
+| Acquire lease    | [https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container](https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container)                   | yes
+| Break lease      | [https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container](https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container)                   | yes
+| Release lease    | [https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container](https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container)                   | yes
+| Renew lease      | [https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container](https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container)                   | yes
 
 #### Storage blobs
 

--- a/src/azure/core/headers.rs
+++ b/src/azure/core/headers.rs
@@ -9,4 +9,6 @@ pub const HAS_IMMUTABILITY_POLICY: &str = "x-ms-has-immutability-policy";
 pub const HAS_LEGAL_HOLD: &str = "x-ms-has-legal-hold";
 pub const META_PREFIX: &str = "x-ms-meta-";
 pub const LEASE_ACTION: &str = "x-ms-lease-action"; //=> [LeaseAction] }
+pub const LEASE_BREAK_PERIOD: &str = "x-ms-lease-break-period"; //=> [u32] }
 pub const PROPOSED_LEASE_ID: &str = "x-ms-proposed-lease-id"; //=> [LeaseId] }
+pub const LEASE_TIME: &str = "x-ms-lease-time";

--- a/src/azure/core/mod.rs
+++ b/src/azure/core/mod.rs
@@ -20,7 +20,7 @@ define_encode_set! {
     }
 }
 pub mod headers;
-use self::headers::{CLIENT_REQUEST_ID, LEASE_DURATION, LEASE_ID, PROPOSED_LEASE_ID};
+use self::headers::{CLIENT_REQUEST_ID, LEASE_BREAK_PERIOD, LEASE_DURATION, LEASE_ID, PROPOSED_LEASE_ID};
 use uuid::Uuid;
 pub type RequestId = Uuid;
 use azure::core::lease::LeaseId;
@@ -170,6 +170,21 @@ pub trait ProposedLeaseIdRequired<'a> {
 
     fn add_header(&self, builder: &mut Builder) {
         builder.header(PROPOSED_LEASE_ID, &self.proposed_lease_id().to_string() as &str);
+    }
+}
+
+pub trait LeaseBreakPeriodSupport {
+    type O;
+    fn with_lease_break_period(self, lease_break_period: u8) -> Self::O;
+}
+
+pub trait LeaseBreakPeriodOption {
+    fn lease_break_period(&self) -> Option<u8>;
+
+    fn add_header(&self, builder: &mut Builder) {
+        if let Some(lease_break_period) = self.lease_break_period() {
+            builder.header(LEASE_BREAK_PERIOD, &lease_break_period.to_string() as &str);
+        }
     }
 }
 

--- a/src/azure/storage/blob/mod.rs
+++ b/src/azure/storage/blob/mod.rs
@@ -35,7 +35,7 @@ mod get_block_list_response;
 pub use self::get_block_list_response::GetBlockListResponse;
 
 use azure::core::headers::{
-    CLIENT_REQUEST_ID, LEASE_ACTION, LEASE_DURATION, LEASE_ID, LEASE_STATE, LEASE_STATUS, PROPOSED_LEASE_ID, REQUEST_ID,
+    CLIENT_REQUEST_ID, LEASE_ACTION, LEASE_BREAK_PERIOD, LEASE_DURATION, LEASE_ID, LEASE_STATE, LEASE_STATUS, PROPOSED_LEASE_ID, REQUEST_ID,
 };
 use base64;
 use chrono::{DateTime, Utc};
@@ -500,7 +500,7 @@ impl Blob {
                 request.header_formatted(LEASE_ACTION, la);
 
                 if let Some(lease_break_period) = lbo.lease_break_period {
-                    request.header_formatted(HEADER_LEASE_BREAK_PERIOD, lease_break_period);
+                    request.header_formatted(LEASE_BREAK_PERIOD, lease_break_period);
                 }
                 if let Some(lease_duration) = lbo.lease_duration {
                     request.header_formatted(LEASE_DURATION, lease_duration);

--- a/src/azure/storage/client.rs
+++ b/src/azure/storage/client.rs
@@ -19,6 +19,7 @@ pub trait Container {
     fn acquire_lease<'a>(&'a self) -> container::requests::AcquireLeaseBuilder<'a, No, No>;
     fn renew_lease<'a>(&'a self) -> container::requests::RenewLeaseBuilder<'a, No, No>;
     fn release_lease<'a>(&'a self) -> container::requests::ReleaseLeaseBuilder<'a, No, No>;
+    fn break_lease<'a>(&'a self) -> container::requests::BreakLeaseBuilder<'a, No>;
 }
 
 #[derive(Debug)]
@@ -63,6 +64,10 @@ impl Container for Client {
 
     fn release_lease<'a>(&'a self) -> container::requests::ReleaseLeaseBuilder<'a, No, No> {
         container::requests::ReleaseLeaseBuilder::new(self)
+    }
+
+    fn break_lease<'a>(&'a self) -> container::requests::BreakLeaseBuilder<'a, No> {
+        container::requests::BreakLeaseBuilder::new(self)
     }
 }
 

--- a/src/azure/storage/container/requests/break_lease_builder.json
+++ b/src/azure/storage/container/requests/break_lease_builder.json
@@ -1,0 +1,49 @@
+{
+	"name": "BreakLeaseBuilder",
+	"extra_types": [ "'a" ],
+	"constructor_fields": [
+		{
+			"name": "client",
+			"field_type": "&'a Client",
+			"trait_get": "ClientRequired<'a>"
+		}
+	],
+	"fields": [
+		{
+			"name": "container_name",
+			"field_type": "&'a str",
+			"builder_type": "ContainerNameSet",
+			"optional": false,
+			"trait_get": "ContainerNameRequired<'a>",
+			"trait_set": "ContainerNameSupport<'a>"
+		},
+		{
+			"name": "client_request_id",
+			"field_type": "&'a str",
+			"optional": true,
+			"trait_get": "ClientRequestIdOption<'a>",
+			"trait_set": "ClientRequestIdSupport<'a>"
+		},
+		{
+			"name": "timeout",
+			"field_type": "u64",
+			"optional": true,
+			"trait_get": "TimeoutOption",
+			"trait_set": "TimeoutSupport"
+		},
+		{
+			"name": "lease_break_period",
+			"field_type": "u8",
+			"optional": true,
+			"trait_get": "LeaseBreakPeriodOption",
+			"trait_set": "LeaseBreakPeriodSupport"
+		},
+		{
+			"name": "lease_id",
+			"field_type": "&'a LeaseId",
+			"optional": true,
+			"trait_get": "LeaseIdOption<'a>",
+			"trait_set": "LeaseIdSupport<'a>"
+		}
+	]
+}

--- a/src/azure/storage/container/requests/break_lease_builder.rs
+++ b/src/azure/storage/container/requests/break_lease_builder.rs
@@ -1,0 +1,221 @@
+use azure::core::errors::{check_status_extract_headers_and_body, AzureError};
+use azure::core::headers::LEASE_ACTION;
+use azure::core::lease::LeaseId;
+use azure::core::{
+    ClientRequestIdOption, ClientRequestIdSupport, ClientRequired, ContainerNameRequired, ContainerNameSupport, LeaseBreakPeriodOption,
+    LeaseBreakPeriodSupport, LeaseIdOption, LeaseIdSupport, TimeoutOption, TimeoutSupport,
+};
+use azure::core::{No, ToAssign, Yes};
+use azure::storage::client::Client;
+use azure::storage::container::responses::BreakLeaseResponse;
+use futures::future::{done, Future};
+use hyper::{Method, StatusCode};
+use std::marker::PhantomData;
+
+#[derive(Debug, Clone)]
+pub struct BreakLeaseBuilder<'a, ContainerNameSet>
+where
+    ContainerNameSet: ToAssign,
+{
+    client: &'a Client,
+    p_container_name: PhantomData<ContainerNameSet>,
+    container_name: Option<&'a str>,
+    client_request_id: Option<&'a str>,
+    timeout: Option<u64>,
+    lease_break_period: Option<u8>,
+    lease_id: Option<&'a LeaseId>,
+}
+
+impl<'a> BreakLeaseBuilder<'a, No> {
+    pub(crate) fn new(client: &'a Client) -> BreakLeaseBuilder<'a, No> {
+        BreakLeaseBuilder {
+            client,
+            p_container_name: PhantomData {},
+            container_name: None,
+            client_request_id: None,
+            timeout: None,
+            lease_break_period: None,
+            lease_id: None,
+        }
+    }
+}
+
+impl<'a, ContainerNameSet> ClientRequired<'a> for BreakLeaseBuilder<'a, ContainerNameSet>
+where
+    ContainerNameSet: ToAssign,
+{
+    fn client(&self) -> &'a Client {
+        self.client
+    }
+}
+
+impl<'a> ContainerNameRequired<'a> for BreakLeaseBuilder<'a, Yes> {
+    fn container_name(&self) -> &'a str {
+        self.container_name.unwrap()
+    }
+}
+
+impl<'a, ContainerNameSet> ClientRequestIdOption<'a> for BreakLeaseBuilder<'a, ContainerNameSet>
+where
+    ContainerNameSet: ToAssign,
+{
+    fn client_request_id(&self) -> Option<&'a str> {
+        self.client_request_id
+    }
+}
+
+impl<'a, ContainerNameSet> TimeoutOption for BreakLeaseBuilder<'a, ContainerNameSet>
+where
+    ContainerNameSet: ToAssign,
+{
+    fn timeout(&self) -> Option<u64> {
+        self.timeout
+    }
+}
+
+impl<'a, ContainerNameSet> LeaseBreakPeriodOption for BreakLeaseBuilder<'a, ContainerNameSet>
+where
+    ContainerNameSet: ToAssign,
+{
+    fn lease_break_period(&self) -> Option<u8> {
+        self.lease_break_period
+    }
+}
+
+impl<'a, ContainerNameSet> LeaseIdOption<'a> for BreakLeaseBuilder<'a, ContainerNameSet>
+where
+    ContainerNameSet: ToAssign,
+{
+    fn lease_id(&self) -> Option<&'a LeaseId> {
+        self.lease_id
+    }
+}
+
+impl<'a, ContainerNameSet> ContainerNameSupport<'a> for BreakLeaseBuilder<'a, ContainerNameSet>
+where
+    ContainerNameSet: ToAssign,
+{
+    type O = BreakLeaseBuilder<'a, Yes>;
+
+    fn with_container_name(self, container_name: &'a str) -> Self::O {
+        BreakLeaseBuilder {
+            client: self.client,
+            p_container_name: PhantomData {},
+            container_name: Some(container_name),
+            client_request_id: self.client_request_id,
+            timeout: self.timeout,
+            lease_break_period: self.lease_break_period,
+            lease_id: self.lease_id,
+        }
+    }
+}
+
+impl<'a, ContainerNameSet> ClientRequestIdSupport<'a> for BreakLeaseBuilder<'a, ContainerNameSet>
+where
+    ContainerNameSet: ToAssign,
+{
+    type O = BreakLeaseBuilder<'a, ContainerNameSet>;
+
+    fn with_client_request_id(self, client_request_id: &'a str) -> Self::O {
+        BreakLeaseBuilder {
+            client: self.client,
+            p_container_name: PhantomData {},
+            container_name: self.container_name,
+            client_request_id: Some(client_request_id),
+            timeout: self.timeout,
+            lease_break_period: self.lease_break_period,
+            lease_id: self.lease_id,
+        }
+    }
+}
+
+impl<'a, ContainerNameSet> TimeoutSupport for BreakLeaseBuilder<'a, ContainerNameSet>
+where
+    ContainerNameSet: ToAssign,
+{
+    type O = BreakLeaseBuilder<'a, ContainerNameSet>;
+
+    fn with_timeout(self, timeout: u64) -> Self::O {
+        BreakLeaseBuilder {
+            client: self.client,
+            p_container_name: PhantomData {},
+            container_name: self.container_name,
+            client_request_id: self.client_request_id,
+            timeout: Some(timeout),
+            lease_break_period: self.lease_break_period,
+            lease_id: self.lease_id,
+        }
+    }
+}
+
+impl<'a, ContainerNameSet> LeaseBreakPeriodSupport for BreakLeaseBuilder<'a, ContainerNameSet>
+where
+    ContainerNameSet: ToAssign,
+{
+    type O = BreakLeaseBuilder<'a, ContainerNameSet>;
+
+    fn with_lease_break_period(self, lease_break_period: u8) -> Self::O {
+        BreakLeaseBuilder {
+            client: self.client,
+            p_container_name: PhantomData {},
+            container_name: self.container_name,
+            client_request_id: self.client_request_id,
+            timeout: self.timeout,
+            lease_break_period: Some(lease_break_period),
+            lease_id: self.lease_id,
+        }
+    }
+}
+
+impl<'a, ContainerNameSet> LeaseIdSupport<'a> for BreakLeaseBuilder<'a, ContainerNameSet>
+where
+    ContainerNameSet: ToAssign,
+{
+    type O = BreakLeaseBuilder<'a, ContainerNameSet>;
+
+    fn with_lease_id(self, lease_id: &'a LeaseId) -> Self::O {
+        BreakLeaseBuilder {
+            client: self.client,
+            p_container_name: PhantomData {},
+            container_name: self.container_name,
+            client_request_id: self.client_request_id,
+            timeout: self.timeout,
+            lease_break_period: self.lease_break_period,
+            lease_id: Some(lease_id),
+        }
+    }
+}
+
+// methods callable regardless
+impl<'a, ContainerNameSet> BreakLeaseBuilder<'a, ContainerNameSet> where ContainerNameSet: ToAssign {}
+
+impl<'a> BreakLeaseBuilder<'a, Yes> {
+    pub fn finalize(self) -> impl Future<Item = BreakLeaseResponse, Error = AzureError> {
+        let mut uri = format!(
+            "https://{}.blob.core.windows.net/{}?comp=lease&restype=container",
+            self.client().account(),
+            self.container_name()
+        );
+
+        if let Some(nm) = TimeoutOption::to_uri_parameter(&self) {
+            uri = format!("{}&{}", uri, nm);
+        }
+
+        let req = self.client().perform_request(
+            &uri,
+            Method::PUT,
+            |ref mut request| {
+                ClientRequestIdOption::add_header(&self, request);
+                LeaseIdOption::add_header(&self, request);
+                request.header(LEASE_ACTION, "break");
+                LeaseBreakPeriodOption::add_header(&self, request);
+            },
+            Some(&[]),
+        );
+
+        done(req)
+            .from_err()
+            .and_then(move |future_response| check_status_extract_headers_and_body(future_response, StatusCode::ACCEPTED))
+            .and_then(|(headers, _body)| done(BreakLeaseResponse::from_response(&headers)))
+    }
+}

--- a/src/azure/storage/container/requests/mod.rs
+++ b/src/azure/storage/container/requests/mod.rs
@@ -1,4 +1,5 @@
 mod acquire_lease_builder;
+mod break_lease_builder;
 mod create_builder;
 mod delete_builder;
 mod get_acl_builder;
@@ -16,3 +17,4 @@ pub use self::list_builder::ListBuilder;
 pub use self::release_lease_builder::ReleaseLeaseBuilder;
 pub use self::renew_lease_builder::RenewLeaseBuilder;
 pub use self::set_acl_builder::SetACLBuilder;
+pub use self::break_lease_builder::BreakLeaseBuilder;

--- a/src/azure/storage/container/requests/release_lease_builder.rs
+++ b/src/azure/storage/container/requests/release_lease_builder.rs
@@ -194,7 +194,7 @@ impl<'a> ReleaseLeaseBuilder<'a, Yes, Yes> {
             |ref mut request| {
                 ClientRequestIdOption::add_header(&self, request);
                 LeaseIdRequired::add_header(&self, request);
-                request.header(LEASE_ACTION, "renew");
+                request.header(LEASE_ACTION, "release");
             },
             Some(&[]),
         );

--- a/src/azure/storage/container/responses/mod.rs
+++ b/src/azure/storage/container/responses/mod.rs
@@ -1,3 +1,4 @@
+mod break_lease_response;
 mod acquire_lease_response;
 mod get_acl_response;
 mod get_properties_response;
@@ -8,3 +9,4 @@ pub use self::get_acl_response::GetACLResponse;
 pub use self::get_properties_response::GetPropertiesResponse;
 pub use self::release_lease_response::ReleaseLeaseResponse;
 pub use self::renew_lease_response::RenewLeaseResponse;
+pub use self::break_lease_response::BreakLeaseResponse;

--- a/src/azure/storage/rest_client.rs
+++ b/src/azure/storage/rest_client.rs
@@ -22,7 +22,6 @@ pub const HEADER_VERSION: &str = "x-ms-version"; //=> [String] }
 pub const HEADER_DATE: &str = "x-ms-date"; //=> [String] }
 pub const HEADER_CONTENT_MD5: &str = "Content-MD5"; //=> [String] }
 pub const HEADER_RANGE: &str = "x-ms-range"; // => [range::Range] }
-pub const HEADER_LEASE_BREAK_PERIOD: &str = "x-ms-lease-break-period"; //=> [u32] }
 pub const HEADER_RANGE_GET_CONTENT_MD5: &str = "x-ms-range-get-content-md5"; //=> [bool] }
 
 fn generate_authorization(h: &HeaderMap, u: &url::Url, method: Method, hmac_key: &str, service_type: ServiceType) -> String {


### PR DESCRIPTION
Also corrected a bug in `release_lease_response`. The header `x-ms-lease-id` is not returned so the response must not expect it.