### PR TITLE
Fixed cosmos queries not returning DocumentAttributes json

### DIFF
--- a/src/azure/cosmos/requests/document_requests.rs
+++ b/src/azure/cosmos/requests/document_requests.rs
@@ -192,11 +192,14 @@ impl QueryDocumentRequest {
             let mut doc = doc.take();
 
             let attrs = {
-                let map = doc.as_object_mut().unwrap();
-                DocumentAttributes::try_extract(map)
+                if let Some(map) = doc.as_object_mut() {
+                    DocumentAttributes::try_extract(map)
+                } else {
+                    None
+                }
             };
 
-            // debug!("\ndocument_attributes == {:?}", document_attributes);
+            debug!("attrs == {:?}", attrs);
 
             QueryResult {
                 document_attributes: attrs,


### PR DESCRIPTION
This PR fixes [https://github.com/MindFlavor/AzureSDKForRust/issues/62](https://github.com/MindFlavor/AzureSDKForRust/issues/62) but checking if the returned document has a `DocumentAttributes` entry as json object (see [https://docs.serde.rs/serde_json/value/enum.Value.html](https://docs.serde.rs/serde_json/value/enum.Value.html)) and parse it only if present.