### PR TITLE
Ability to connect to the development server.

### DIFF
--- a/examples/blob00.rs
+++ b/examples/blob00.rs
@@ -31,7 +31,7 @@ fn code() -> Result<(), Box<Error>> {
 
     let mut core = Core::new()?;
 
-    let client = Client::new(&account, &master_key)?;
+    let client = Client::new(Account::Azure { account, key: master_key })?;
 
     trace!("Requesting blog");
 

--- a/examples/blob02.rs
+++ b/examples/blob02.rs
@@ -29,7 +29,7 @@ fn code() -> Result<(), Box<Error>> {
         .expect("please specify container name as command line parameter");
 
     let mut core = Core::new()?;
-    let client = Client::new(&account, &master_key)?;
+    let client = Client::new(Account::Azure { account, key: master_key })?;
 
     let future = client
         .list_blobs()

--- a/examples/container00.rs
+++ b/examples/container00.rs
@@ -26,7 +26,7 @@ fn code() -> Result<(), Box<Error>> {
 
     let mut core = Core::new()?;
 
-    let client = Client::new(&account, &master_key)?;
+    let client = Client::new(Account::Azure { account, key: master_key })?;
 
     let future = {
         use azure_sdk_for_rust::storage::client::Container;

--- a/examples/container01.rs
+++ b/examples/container01.rs
@@ -31,7 +31,7 @@ fn code() -> Result<(), Box<Error>> {
 
     let mut core = Core::new()?;
 
-    let client = Client::new(&account, &master_key)?;
+    let client = Client::new(Account::Azure { account, key: master_key })?;
 
     use azure_sdk_for_rust::storage::client::Container;
 

--- a/examples/container_and_blob.rs
+++ b/examples/container_and_blob.rs
@@ -32,7 +32,7 @@ fn code() -> Result<(), Box<Error>> {
 
     let mut core = Core::new()?;
 
-    let client = Client::new(&account, &master_key)?;
+    let client = Client::new(Account::Azure { account, key: master_key })?;
 
     // create container
     let future = client

--- a/examples/put_append_blob00.rs
+++ b/examples/put_append_blob00.rs
@@ -34,7 +34,7 @@ fn code() -> Result<(), Box<Error>> {
 
     let mut core = Core::new()?;
 
-    let client = Client::new(&account, &master_key)?;
+    let client = Client::new(Account::Azure { account, key: master_key })?;
 
     let data = b"something";
 

--- a/examples/put_block_blob00.rs
+++ b/examples/put_block_blob00.rs
@@ -38,7 +38,7 @@ fn code() -> Result<(), Box<Error>> {
 
     let mut core = Core::new()?;
 
-    let client = Client::new(&account, &master_key)?;
+    let client = Client::new(Account::Azure { account, key: master_key })?;
 
     let data = b"something";
 

--- a/examples/put_page_blob00.rs
+++ b/examples/put_page_blob00.rs
@@ -37,7 +37,7 @@ fn code() -> Result<(), Box<Error>> {
 
     let mut core = Core::new()?;
 
-    let client = Client::new(&account, &master_key)?;
+    let client = Client::new(Account::Azure { account, key: master_key })?;
 
     let data: [u8; 2000] = [51; 2000];
 

--- a/examples/stream_blob00.rs
+++ b/examples/stream_blob00.rs
@@ -33,7 +33,7 @@ fn code() -> Result<(), Box<std::error::Error>> {
         .expect("please specify container name as first command line parameter");
 
     let mut reactor = Core::new()?;
-    let client = Client::new(&account, &master_key)?;
+    let client = Client::new(Account::Azure { account, key: master_key })?;
 
     let string = "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF";
 

--- a/src/azure/storage/blob/mod.rs
+++ b/src/azure/storage/blob/mod.rs
@@ -370,15 +370,15 @@ where
 {
     match params {
         Some(ref params) => format!(
-            "https://{}.blob.core.windows.net/{}/{}?{}",
-            t.client().account(),
+            "{}/{}/{}?{}",
+            t.client().uri_builder().blob_uri(),
             utf8_percent_encode(t.container_name(), COMPLETE_ENCODE_SET),
             utf8_percent_encode(t.blob_name(), COMPLETE_ENCODE_SET),
             params
         ),
         None => format!(
-            "https://{}.blob.core.windows.net/{}/{}",
-            t.client().account(),
+            "{}/{}/{}",
+            t.client().uri_builder().blob_uri(),
             utf8_percent_encode(t.container_name(), COMPLETE_ENCODE_SET),
             utf8_percent_encode(t.blob_name(), COMPLETE_ENCODE_SET)
         ),

--- a/src/azure/storage/container/mod.rs
+++ b/src/azure/storage/container/mod.rs
@@ -229,14 +229,14 @@ where
 {
     match params {
         Some(ref params) => format!(
-            "https://{}.blob.core.windows.net/{}?{}",
-            t.client().account(),
+            "{}/{}?{}",
+            t.client().uri_builder().blob_uri(),
             utf8_percent_encode(t.container_name(), COMPLETE_ENCODE_SET),
             params
         ),
         None => format!(
-            "https://{}.blob.core.windows.net/{}",
-            t.client().account(),
+            "{}/{}",
+            t.client().uri_builder().blob_uri(),
             utf8_percent_encode(t.container_name(), COMPLETE_ENCODE_SET),
         ),
     }

--- a/src/azure/storage/container/requests/acquire_lease_builder.rs
+++ b/src/azure/storage/container/requests/acquire_lease_builder.rs
@@ -255,8 +255,8 @@ where
 impl<'a> AcquireLeaseBuilder<'a, Yes, Yes> {
     pub fn finalize(self) -> impl Future<Item = AcquireLeaseResponse, Error = AzureError> {
         let mut uri = format!(
-            "https://{}.blob.core.windows.net/{}?comp=lease&restype=container",
-            self.client().account(),
+            "{}/{}?comp=lease&restype=container",
+            self.client().uri_builder().blob_uri(),
             self.container_name()
         );
 

--- a/src/azure/storage/container/requests/break_lease_builder.rs
+++ b/src/azure/storage/container/requests/break_lease_builder.rs
@@ -192,8 +192,8 @@ impl<'a, ContainerNameSet> BreakLeaseBuilder<'a, ContainerNameSet> where Contain
 impl<'a> BreakLeaseBuilder<'a, Yes> {
     pub fn finalize(self) -> impl Future<Item = BreakLeaseResponse, Error = AzureError> {
         let mut uri = format!(
-            "https://{}.blob.core.windows.net/{}?comp=lease&restype=container",
-            self.client().account(),
+            "{}/{}?comp=lease&restype=container",
+            self.client().uri_builder().blob_uri(),
             self.container_name()
         );
 

--- a/src/azure/storage/container/requests/create_builder.rs
+++ b/src/azure/storage/container/requests/create_builder.rs
@@ -215,8 +215,8 @@ impl<'a> CreateBuilder<'a, No, No> {
 impl<'a> CreateBuilder<'a, Yes, Yes> {
     pub fn finalize(self) -> impl Future<Item = (), Error = AzureError> {
         let mut uri = format!(
-            "https://{}.blob.core.windows.net/{}?restype=container",
-            self.client().account(),
+            "{}/{}?restype=container",
+            self.client().uri_builder().blob_uri(),
             self.container_name()
         );
 
@@ -243,11 +243,12 @@ impl<'a> CreateBuilder<'a, Yes, Yes> {
 
 #[cfg(test)]
 mod test {
+    use azure::storage::client::Account;
     use super::*;
 
     #[test]
     fn alloc() {
-        let client = Client::new("a", "b").unwrap();
+        let client = Client::new(Account::Azure { account: "a".to_string(), key: "b".to_string() }).unwrap();
         let create = CreateBuilder::new(&client)
             .with_container_name("ciccio")
             .with_public_access(PublicAccess::None);

--- a/src/azure/storage/container/requests/delete_builder.rs
+++ b/src/azure/storage/container/requests/delete_builder.rs
@@ -147,8 +147,8 @@ impl<'a> DeleteBuilder<'a, No> {
 impl<'a> DeleteBuilder<'a, Yes> {
     pub fn finalize(self) -> impl Future<Item = (), Error = AzureError> {
         let mut uri = format!(
-            "https://{}.blob.core.windows.net/{}?restype=container",
-            self.client().account(),
+            "{}/{}?restype=container",
+            self.client().uri_builder().blob_uri(),
             self.container_name()
         );
 
@@ -174,11 +174,12 @@ impl<'a> DeleteBuilder<'a, Yes> {
 
 #[cfg(test)]
 mod test {
+    use azure::storage::client::Account;
     use super::*;
 
     #[test]
     fn alloc() {
-        let client = Client::new("a", "b").unwrap();
+        let client = Client::new(Account::Azure { account: "a".to_string(), key: "b".to_string() }).unwrap();
         let del = DeleteBuilder::new(&client).with_container_name("ciccio");
         println!("container_name == {}", del.container_name());
         // this would fail as Client was not set

--- a/src/azure/storage/container/requests/get_acl_builder.rs
+++ b/src/azure/storage/container/requests/get_acl_builder.rs
@@ -73,8 +73,8 @@ where
 impl<'a> GetACLBuilder<'a, Yes> {
     pub fn finalize(self) -> impl Future<Item = GetACLResponse, Error = AzureError> {
         let mut uri = format!(
-            "https://{}.blob.core.windows.net/{}?restype=container&comp=acl",
-            self.client().account(),
+            "{}/{}?restype=container&comp=acl",
+            self.client().uri_builder().blob_uri(),
             self.container_name()
         );
 

--- a/src/azure/storage/container/requests/get_properties_builder.rs
+++ b/src/azure/storage/container/requests/get_properties_builder.rs
@@ -73,8 +73,8 @@ where
 impl<'a> GetPropertiesBuilder<'a, Yes> {
     pub fn finalize(self) -> impl Future<Item = GetPropertiesResponse, Error = AzureError> {
         let mut uri = format!(
-            "https://{}.blob.core.windows.net/{}?restype=container",
-            self.client().account(),
+            "{}/{}?restype=container",
+            self.client().uri_builder().blob_uri(),
             self.container_name()
         );
 

--- a/src/azure/storage/container/requests/list_builder.rs
+++ b/src/azure/storage/container/requests/list_builder.rs
@@ -79,8 +79,8 @@ impl<'a> ListBuilder<'a> {
 
     pub fn finalize(self) -> impl Future<Item = ListContainersResponse, Error = AzureError> {
         let mut uri = format!(
-            "https://{}.blob.core.windows.net?comp=list&maxresults={}",
-            self.client().account(),
+            "{}?comp=list&maxresults={}",
+            self.client().uri_builder().blob_uri(),
             self.max_results()
         );
 

--- a/src/azure/storage/container/requests/release_lease_builder.rs
+++ b/src/azure/storage/container/requests/release_lease_builder.rs
@@ -179,8 +179,8 @@ where
 impl<'a> ReleaseLeaseBuilder<'a, Yes, Yes> {
     pub fn finalize(self) -> impl Future<Item = ReleaseLeaseResponse, Error = AzureError> {
         let mut uri = format!(
-            "https://{}.blob.core.windows.net/{}?comp=lease&restype=container",
-            self.client().account(),
+            "{}/{}?comp=lease&restype=container",
+            self.client().uri_builder().blob_uri(),
             self.container_name()
         );
 

--- a/src/azure/storage/container/requests/renew_lease_builder.rs
+++ b/src/azure/storage/container/requests/renew_lease_builder.rs
@@ -179,8 +179,8 @@ where
 impl<'a> RenewLeaseBuilder<'a, Yes, Yes> {
     pub fn finalize(self) -> impl Future<Item = RenewLeaseResponse, Error = AzureError> {
         let mut uri = format!(
-            "https://{}.blob.core.windows.net/{}?comp=lease&restype=container",
-            self.client().account(),
+            "{}/{}?comp=lease&restype=container",
+            self.client().uri_builder().blob_uri(),
             self.container_name()
         );
 

--- a/src/azure/storage/container/requests/set_acl_builder.rs
+++ b/src/azure/storage/container/requests/set_acl_builder.rs
@@ -113,8 +113,8 @@ where
 impl<'a> SetACLBuilder<'a, Yes, Yes> {
     pub fn finalize(self) -> impl Future<Item = PublicAccess, Error = AzureError> {
         let mut uri = format!(
-            "https://{}.blob.core.windows.net/{}?restype=container&comp=acl",
-            self.client().account(),
+            "{}/{}?restype=container&comp=acl",
+            self.client().uri_builder().blob_uri(),
             self.container_name()
         );
 

--- a/src/azure/storage/rest_client.rs
+++ b/src/azure/storage/rest_client.rs
@@ -147,7 +147,10 @@ fn get_account(u: &url::Url) -> String {
             let first_dot = dm.find('.').unwrap();
             String::from(&dm[0..first_dot])
         }
-        _ => panic!("only Domains are supported in canonicalized_resource"),
+        // TODO find a proper way to determine we are connecting to the
+        // development server.
+        _ => "devstoreaccount1".to_string(),
+        //_ => panic!("only Domains are supported in canonicalized_resource"),
     }
 }
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -17,4 +17,4 @@ pub use azure::core::{
 };
 pub use azure::storage::container::PublicAccessSupport;
 
-pub use azure::storage::client::{Blob as BlobTrait, Client, Container as ContainerTrait};
+pub use azure::storage::client::{Blob as BlobTrait, Account, Client, Container as ContainerTrait};

--- a/tests/append_blob.rs
+++ b/tests/append_blob.rs
@@ -68,5 +68,5 @@ fn initialize() -> Result<(Client, Core), AzureError> {
     let master_key = std::env::var("STORAGE_MASTER_KEY").expect("Set env variable STORAGE_MASTER_KEY first!");
     let core = Core::new()?;
 
-    Ok((Client::new(&account, &master_key)?, core))
+    Ok((Client::new(Account::Azure { account, key: master_key })?, core))
 }

--- a/tests/blob.rs
+++ b/tests/blob.rs
@@ -313,5 +313,5 @@ fn initialize() -> Result<(Client, Core), AzureError> {
     let master_key = std::env::var("STORAGE_MASTER_KEY").expect("Set env variable STORAGE_MASTER_KEY first!");
     let core = Core::new()?;
 
-    Ok((Client::new(&account, &master_key)?, core))
+    Ok((Client::new(Account::Azure { account, key: master_key })?, core))
 }

--- a/tests/container.rs
+++ b/tests/container.rs
@@ -13,7 +13,7 @@ extern crate uuid;
 use azure_sdk_for_rust::core::errors::AzureError;
 use azure_sdk_for_rust::core::{ContainerNameSupport, LeaseBreakPeriodSupport, LeaseDurationSupport, LeaseIdSupport};
 use azure_sdk_for_rust::storage::{
-    client::Client,
+    client::{Account, Client},
     container::{PublicAccess, PublicAccessSupport},
 };
 use tokio_core::reactor::Core;
@@ -100,5 +100,5 @@ fn initialize() -> Result<(Client, Core), AzureError> {
     let master_key = std::env::var("STORAGE_MASTER_KEY").expect("Set env variable STORAGE_MASTER_KEY first!");
     let core = Core::new()?;
 
-    Ok((Client::new(&account, &master_key)?, core))
+    Ok((Client::new(Account::Azure { account, key: master_key })?, core))
 }

--- a/tests/page_blob.rs
+++ b/tests/page_blob.rs
@@ -70,5 +70,5 @@ fn initialize() -> Result<(Client, Core), AzureError> {
     let master_key = std::env::var("STORAGE_MASTER_KEY").expect("Set env variable STORAGE_MASTER_KEY first!");
     let core = Core::new()?;
 
-    Ok((Client::new(&account, &master_key)?, core))
+    Ok((Client::new(Account::Azure { account, key: master_key })?, core))
 }

--- a/tests/stream_blob00.rs
+++ b/tests/stream_blob00.rs
@@ -29,7 +29,7 @@ fn code() -> Result<(), Box<std::error::Error>> {
     let master_key = std::env::var("STORAGE_MASTER_KEY").expect("Set env variable STORAGE_MASTER_KEY first!");
 
     let mut reactor = Core::new()?;
-    let client = Client::new(&account, &master_key)?;
+    let client = Client::new(Account::Azure { account, key: master_key })?;
 
     if reactor
         .run(client.list_containers().finalize())?


### PR DESCRIPTION
This is an attempt at connecting to the azure storage emulator for development purposes.

It breaks the API for the Client creation. If that's not an option, please advise on e.g. a new constructor name.

There is also an issue deep in the rest client when it comes to the generation of the authentication header. I'm not aware of the Azure requirements here so I temporarily returned the development account name by default. Do you have any idea to make it better?

All in all, I can now connect to the emulator and do stuff.