### PR TITLE
Remove println when streaming blob

### DIFF
--- a/src/azure/storage/blob/blob_stream_builder.rs
+++ b/src/azure/storage/blob/blob_stream_builder.rs
@@ -373,7 +373,6 @@ impl<'a> BlobStreamBuilder<'a, Yes, Yes, Yes> {
             } else {
                 Range::new(remaining.start, remaining.start + increment)
             };
-            println!("getting blob {:?} out of {:?}", range, remaining);
 
             let mut req = GetBlobBuilder::new(&client)
                 .with_container_name(&container_name)


### PR DESCRIPTION
This is just a trivial PR to remove a `println!` that must have been forgotten while developing!
It stuck somewhere in the `BlobStreamBuilder` and prevents from outputting anything to stdout.
Thanks