### PR TITLE
Feature/add parallelize cross partition query

### DIFF
--- a/src/azure/cosmos/client.rs
+++ b/src/azure/cosmos/client.rs
@@ -50,7 +50,8 @@ pub(crate) mod headers {
     pub const HEADER_REQUEST_CHARGE: &str = "x-ms-request-charge"; // [f64]
     pub const HEADER_DOCUMENTDB_PARTITIONKEY: &str = "x-ms-documentdb-partitionkey"; // [String]
     pub const HEADER_DOCUMENTDB_ISQUERY: &str = "x-ms-documentdb-isquery"; // [bool]
-    pub const HEADER_DOCUMENTDB_QUERY_ENABLECROSSPARTITION: &str = "x-ms-documentdb-query-enablecrosspartition"; // [bool]
+    pub const HEADER_DOCUMENTDB_QUERY_ENABLECROSSPARTITION: &str = "x-ms-documentdb-query-enablecrosspartition";
+    pub const HEADER_DOCUMENTDB_QUERY_PARALLELIZECROSSPARTITION: &str = "x-ms-documentdb-query-parallelizecrosspartitionquery"; // [bool]
 }
 use self::headers::*;
 

--- a/src/azure/cosmos/client.rs
+++ b/src/azure/cosmos/client.rs
@@ -51,7 +51,7 @@ pub(crate) mod headers {
     pub const HEADER_DOCUMENTDB_PARTITIONKEY: &str = "x-ms-documentdb-partitionkey"; // [String]
     pub const HEADER_DOCUMENTDB_ISQUERY: &str = "x-ms-documentdb-isquery"; // [bool]
     pub const HEADER_DOCUMENTDB_QUERY_ENABLECROSSPARTITION: &str = "x-ms-documentdb-query-enablecrosspartition"; // [bool]
-    pub const HEADER_DOCUMENTDB_QUERY_PARALLELIZECROSSPARTITION: &str = "x-ms-documentdb-query-parallelizecrosspartitionquery"; // [bool]
+    pub const HEADER_DOCUMENTDB_QUERY_PARALLELIZECROSSPARTITIONQUERY: &str = "x-ms-documentdb-query-parallelizecrosspartitionquery"; // [bool]
 }
 use self::headers::*;
 

--- a/src/azure/cosmos/client.rs
+++ b/src/azure/cosmos/client.rs
@@ -50,7 +50,7 @@ pub(crate) mod headers {
     pub const HEADER_REQUEST_CHARGE: &str = "x-ms-request-charge"; // [f64]
     pub const HEADER_DOCUMENTDB_PARTITIONKEY: &str = "x-ms-documentdb-partitionkey"; // [String]
     pub const HEADER_DOCUMENTDB_ISQUERY: &str = "x-ms-documentdb-isquery"; // [bool]
-    pub const HEADER_DOCUMENTDB_QUERY_ENABLECROSSPARTITION: &str = "x-ms-documentdb-query-enablecrosspartition";
+    pub const HEADER_DOCUMENTDB_QUERY_ENABLECROSSPARTITION: &str = "x-ms-documentdb-query-enablecrosspartition"; // [bool]
     pub const HEADER_DOCUMENTDB_QUERY_PARALLELIZECROSSPARTITION: &str = "x-ms-documentdb-query-parallelizecrosspartitionquery"; // [bool]
 }
 use self::headers::*;

--- a/src/azure/cosmos/requests/document_requests.rs
+++ b/src/azure/cosmos/requests/document_requests.rs
@@ -138,6 +138,7 @@ impl QueryDocumentRequest {
     request_option!(max_item_count, u64, HEADER_MAX_ITEM_COUNT);
     request_bytes_ref!(continuation_token, str, HEADER_CONTINUATION);
     request_option!(enable_cross_partition, bool, HEADER_DOCUMENTDB_QUERY_ENABLECROSSPARTITION);
+    request_option!(enable_parallelize_cross_partition_query, bool, HEADER_DOCUMENTDB_QUERY_PARALLELIZECROSSPARTITION);
     request_option!(consistency_level, ConsistencyLevel, HEADER_CONSISTENCY_LEVEL);
 
     pub fn execute<T: DeserializeOwned>(self) -> impl Future<Item = QueryDocumentResponse<T>, Error = AzureError> {

--- a/src/azure/cosmos/requests/document_requests.rs
+++ b/src/azure/cosmos/requests/document_requests.rs
@@ -138,7 +138,7 @@ impl QueryDocumentRequest {
     request_option!(max_item_count, u64, HEADER_MAX_ITEM_COUNT);
     request_bytes_ref!(continuation_token, str, HEADER_CONTINUATION);
     request_option!(enable_cross_partition, bool, HEADER_DOCUMENTDB_QUERY_ENABLECROSSPARTITION);
-    request_option!(enable_parallelize_cross_partition_query, bool, HEADER_DOCUMENTDB_QUERY_PARALLELIZECROSSPARTITION);
+    request_option!(enable_parallelize_cross_partition_query, bool, HEADER_DOCUMENTDB_QUERY_PARALLELIZECROSSPARTITIONQUERY);
     request_option!(consistency_level, ConsistencyLevel, HEADER_CONSISTENCY_LEVEL);
 
     pub fn execute<T: DeserializeOwned>(self) -> impl Future<Item = QueryDocumentResponse<T>, Error = AzureError> {


### PR DESCRIPTION
For Cosmos DB enables

x-ms-documentdb-query-parallelizecrosspartitionquery

on Queries