### PR TITLE
Add Use Multiple Write Locations to all Cosmos requests to match JS SDK

### DIFF
--- a/src/azure/cosmos/client.rs
+++ b/src/azure/cosmos/client.rs
@@ -53,7 +53,6 @@ pub(crate) mod headers {
     pub const HEADER_DOCUMENTDB_ISQUERY: &str = "x-ms-documentdb-isquery"; // [bool]
     pub const HEADER_DOCUMENTDB_QUERY_ENABLECROSSPARTITION: &str = "x-ms-documentdb-query-enablecrosspartition"; // [bool]
     pub const HEADER_DOCUMENTDB_QUERY_PARALLELIZECROSSPARTITIONQUERY: &str = "x-ms-documentdb-query-parallelizecrosspartitionquery"; // [bool]
-
 }
 use self::headers::*;
 

--- a/src/azure/cosmos/client.rs
+++ b/src/azure/cosmos/client.rs
@@ -45,6 +45,7 @@ pub(crate) mod headers {
     pub const HEADER_CONTINUATION: &str = "x-ms-continuation"; // [ContinuationToken]
     pub const HEADER_CONSISTENCY_LEVEL: &str = "x-ms-consistency-level"; // [ConsistencyLevel]
     pub const HEADER_SESSION_TOKEN: &str = "x-ms-session-token"; // [ContinuationToken]
+    pub const HEADER_ALLOW_MULTIPLE_WRITES: &str = "x-ms-cosmos-allow-tentative-writes"; // [bool]
     pub const HEADER_A_IM: &str = "A-IM"; // Cow[str]
     pub const HEADER_DOCUMENTDB_PARTITIONRANGEID: &str = "x-ms-documentdb-partitionkeyrangeid"; // [String]
     pub const HEADER_REQUEST_CHARGE: &str = "x-ms-request-charge"; // [f64]
@@ -52,6 +53,7 @@ pub(crate) mod headers {
     pub const HEADER_DOCUMENTDB_ISQUERY: &str = "x-ms-documentdb-isquery"; // [bool]
     pub const HEADER_DOCUMENTDB_QUERY_ENABLECROSSPARTITION: &str = "x-ms-documentdb-query-enablecrosspartition"; // [bool]
     pub const HEADER_DOCUMENTDB_QUERY_PARALLELIZECROSSPARTITIONQUERY: &str = "x-ms-documentdb-query-parallelizecrosspartitionquery"; // [bool]
+
 }
 use self::headers::*;
 

--- a/src/azure/cosmos/requests/document_requests.rs
+++ b/src/azure/cosmos/requests/document_requests.rs
@@ -28,6 +28,7 @@ impl CreateDocumentRequest {
     request_option!(is_upsert, bool, HEADER_DOCUMENTDB_IS_UPSERT);
     request_option!(indexing_directive, IndexingDirective, HEADER_INDEXING_DIRECTIVE);
     request_bytes_ref!(partition_key, str, HEADER_DOCUMENTDB_PARTITIONKEY);
+    request_option!(use_multiple_write_locations, bool, HEADER_ALLOW_MULTIPLE_WRITES);
 
     pub fn execute(self) -> impl Future<Item = DocumentAttributes, Error = AzureError> {
         trace!("get_document called(request == {:?}", self.request);
@@ -59,6 +60,7 @@ impl GetDocumentRequest {
 
     request_bytes_ref!(if_none_match, str, header::IF_NONE_MATCH);
     request_bytes_ref!(partition_key, str, HEADER_DOCUMENTDB_PARTITIONKEY);
+    request_option!(use_multiple_write_locations, bool, HEADER_ALLOW_MULTIPLE_WRITES);
 
     pub fn execute<T: DeserializeOwned>(mut self) -> impl Future<Item = GetDocumentResponse<T>, Error = AzureError> {
         trace!("get_document called(request == {:?}", self.request);
@@ -145,6 +147,7 @@ impl QueryDocumentRequest {
         bool,
         HEADER_DOCUMENTDB_QUERY_PARALLELIZECROSSPARTITIONQUERY
     );
+    request_option!(use_multiple_write_locations, bool, HEADER_ALLOW_MULTIPLE_WRITES);
     request_option!(consistency_level, ConsistencyLevel, HEADER_CONSISTENCY_LEVEL);
 
     pub fn execute<T: DeserializeOwned>(self) -> impl Future<Item = QueryDocumentResponse<T>, Error = AzureError> {
@@ -259,6 +262,7 @@ impl ListDocumentsRequest {
     request_bytes_ref!(session_token, str, HEADER_SESSION_TOKEN);
     request_bytes_ref!(if_none_match, str, header::IF_NONE_MATCH);
     request_bytes_ref!(partition_range_id, str, HEADER_DOCUMENTDB_PARTITIONRANGEID);
+    request_option!(use_multiple_write_locations, bool, HEADER_ALLOW_MULTIPLE_WRITES);
 
     pub fn incremental_feed(mut self) -> Self {
         self.request.header(HEADER_A_IM, HeaderValue::from_static("Incremental feed"));
@@ -350,6 +354,7 @@ impl<T: DeserializeOwned> ReplaceDocumentRequest<T> {
     request_bytes_ref!(if_match, str, header::IF_MATCH);
     request_option!(indexing_directive, IndexingDirective, HEADER_INDEXING_DIRECTIVE);
     request_bytes_ref!(partition_key, str, HEADER_DOCUMENTDB_PARTITIONKEY);
+    request_option!(use_multiple_write_locations, bool, HEADER_ALLOW_MULTIPLE_WRITES);
 
     pub fn execute(self) -> impl Future<Item = ReplaceDocumentResponse<T>, Error = AzureError> {
         trace!("get_document called(request == {:?}", self.request);
@@ -390,6 +395,7 @@ impl DeleteDocumentRequest {
 
     request_bytes_ref!(if_match, str, header::IF_MATCH);
     request_bytes_ref!(partition_key, str, HEADER_DOCUMENTDB_PARTITIONKEY);
+    request_option!(use_multiple_write_locations, bool, HEADER_ALLOW_MULTIPLE_WRITES);
 
     pub fn execute(mut self) -> impl Future<Item = (), Error = AzureError> {
         trace!("get_document called(request == {:?}", self.request);

--- a/src/azure/cosmos/requests/sproc_requests.rs
+++ b/src/azure/cosmos/requests/sproc_requests.rs
@@ -26,6 +26,7 @@ impl ExecuteStoredProcedureRequest {
     }
 
     request_bytes_ref!(partition_key, str, HEADER_DOCUMENTDB_PARTITIONKEY);
+    request_option!(use_multiple_write_locations, bool, HEADER_ALLOW_MULTIPLE_WRITES);
 
     pub fn execute<R: DeserializeOwned>(self) -> impl Future<Item = ExecuteStoredProcedureResponse<R>, Error = AzureError> {
         trace!("execute_stored_procedure called(request == {:?}", self.request);


### PR DESCRIPTION
As per https://docs.microsoft.com/en-us/azure/cosmos-db/how-to-manage-database-account#configure-clients-for-multi-homing

and 
https://github.com/Azure/azure-cosmos-js/blob/master/src/request/request.ts#L174
and 
https://github.com/Azure/azure-cosmos-js/blob/master/src/common/constants.ts#L159