### PR TITLE
Getter/setters

### DIFF
--- a/azure_sdk_cosmos/Cargo.toml
+++ b/azure_sdk_cosmos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "azure_sdk_cosmos"
-version       = "0.22.0"
+version       = "0.23.0"
 description   = "Rust wrappers around Microsoft Azure REST APIs - Azure Cosmos DB crate"
 readme        = "README.md"
 authors       = ["Francesco Cogno <francesco.cogno@outlook.com>", "Max Gortman <mgortman@microsoft.com>"]

--- a/azure_sdk_cosmos/examples/document_entries00.rs
+++ b/azure_sdk_cosmos/examples/document_entries00.rs
@@ -128,7 +128,7 @@ fn code() -> Result<(), Box<dyn Error>> {
             client
                 .replace_document(&database_name, &collection_name, &doc)
                 .partition_key(&id)
-                .if_match(doc.document_attributes.etag) // use optimistic concurrency check
+                .if_match(doc.document_attributes.etag()) // use optimistic concurrency check
                 .execute(),
         )
         .unwrap();

--- a/azure_sdk_cosmos/src/client.rs
+++ b/azure_sdk_cosmos/src/client.rs
@@ -572,10 +572,10 @@ where
         );
 
         let req = self.prepare_request_with_resource_link(
-            &document.document_attributes._self,
+            &document.document_attributes._self(),
             hyper::Method::PUT,
             ResourceType::Documents,
-            &document.document_attributes.rid.to_lowercase(),
+            &document.document_attributes.rid().to_lowercase(),
         );
 
         ReplaceDocumentRequest::new(self.hyper_client.clone(), req, document_serialized)

--- a/azure_sdk_cosmos/src/document.rs
+++ b/azure_sdk_cosmos/src/document.rs
@@ -33,18 +33,81 @@ impl FromStr for IndexingDirective {
 pub struct DocumentAttributes {
     id: String,
     #[serde(rename = "_rid")]
-    pub rid: String,
+    rid: String,
     #[serde(rename = "_ts")]
-    pub ts: u64,
+    ts: u64,
     #[serde(rename = "_self")]
-    pub _self: String,
+    _self: String,
     #[serde(rename = "_etag")]
-    pub etag: String,
+    etag: String,
     #[serde(rename = "_attachments")]
-    pub attachments: String,
+    attachments: String,
 }
 
 impl DocumentAttributes {
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    pub fn rid(&self) -> &str {
+        &self.rid
+    }
+
+    pub fn ts(&self) -> u64 {
+        self.ts
+    }
+
+    pub fn _self(&self) -> &str {
+        &self._self
+    }
+
+    pub fn etag(&self) -> &str {
+        &self.etag
+    }
+
+    pub fn attachments(&self) -> &str {
+        &self.attachments
+    }
+
+    pub fn set_id<T>(&mut self, value: T)
+    where
+        T: Into<String>,
+    {
+        self.id = value.into();
+    }
+
+    pub fn set_rid<T>(&mut self, value: T)
+    where
+        T: Into<String>,
+    {
+        self.rid = value.into();
+    }
+
+    pub fn set_ts(&mut self, value: u64) {
+        self.ts = value;
+    }
+
+    pub fn set_self<T>(&mut self, value: T)
+    where
+        T: Into<String>,
+    {
+        self._self = value.into();
+    }
+
+    pub fn set_etag<T>(&mut self, value: T)
+    where
+        T: Into<String>,
+    {
+        self.etag = value.into();
+    }
+
+    pub fn set_attachments<T>(&mut self, value: T)
+    where
+        T: Into<String>,
+    {
+        self.attachments = value.into();
+    }
+
     pub(crate) fn try_extract(from: &mut ::serde_json::Map<String, ::serde_json::Value>) -> Option<DocumentAttributes> {
         let id = from.get("id")?.as_str()?.to_owned();
         let rid = from.remove("_rid")?.as_str()?.to_owned();
@@ -61,5 +124,25 @@ impl DocumentAttributes {
             etag,
             attachments,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_mutate() {
+        use super::*;
+
+        let mut a = DocumentAttributes {
+            id: "id".to_owned(),
+            rid: "rid".to_owned(),
+            ts: 100,
+            _self: "_self".to_owned(),
+            etag: "etag".to_owned(),
+            attachments: "attachments".to_owned(),
+        };
+
+        a.set_id("new_id");
+        a.set_attachments("new_attachments".to_owned());
     }
 }


### PR DESCRIPTION
Export DocumentAttributes's ID as getter/setter (see issue [https://github.com/MindFlavor/AzureSDKForRust/issues/137](https://github.com/MindFlavor/AzureSDKForRust/issues/137)).