### PR TITLE
add count_blobs example

### DIFF
--- a/azure_sdk_storage_blob/examples/count_blobs.rs
+++ b/azure_sdk_storage_blob/examples/count_blobs.rs
@@ -1,0 +1,44 @@
+use azure_sdk_core::prelude::*;
+use azure_sdk_storage_blob::prelude::*;
+use azure_sdk_storage_core::prelude::*;
+use futures::future::*;
+use std::error::Error;
+use tokio_core::reactor::Core;
+
+fn main() {
+    code().unwrap();
+}
+
+fn code() -> Result<(), Box<dyn Error>> {
+    let account = std::env::var("STORAGE_ACCOUNT").expect("Set env variable STORAGE_ACCOUNT first!");
+    let master_key = std::env::var("STORAGE_MASTER_KEY").expect("Set env variable STORAGE_MASTER_KEY first!");
+
+    let container = std::env::args()
+        .nth(1)
+        .expect("please specify container name as command line parameter");
+    
+    let mut core = Core::new()?;
+    let client = Client::new(&account, &master_key)?;
+
+    let mut count = 0;
+    let mut next_marker: Option<String> = None;
+
+    loop {
+        let mut list_blobs = client.list_blobs().with_container_name(&container);
+        if let Some(ref marker) = next_marker {
+            list_blobs = list_blobs.with_next_marker(marker);
+        }
+        let future = list_blobs.finalize().map(|iv| {
+            count += iv.incomplete_vector.len();
+            next_marker = iv.incomplete_vector.token;
+        });
+        core.run(future)?;
+        if next_marker.is_none(){
+            break;
+        }
+    }
+
+    println!("blob count {}", count);
+
+    Ok(())
+}


### PR DESCRIPTION
I wrote this example to see how to page through the results with the next marker. It pages through the results and returns the total count of blobs.

To test it, I ran a [create_blobs.rs](https://gist.github.com/ctaggart/8b86ce938943443ebd85f4a7aa74ca4f) to populate a container with something more than 5000 results so that it would be forced to page.