### PR TITLE
Add stream_query_entities

### DIFF
--- a/azure_sdk_storage_table/src/table/mod.rs
+++ b/azure_sdk_storage_table/src/table/mod.rs
@@ -123,18 +123,18 @@ impl TableService {
             .and_then(move |future_response| check_status_extract_headers_and_body(future_response, StatusCode::OK))
             .and_then(move |(headers, body)| done({
                 serde_json::from_slice::<EntityCollection<T>>(&body)
-                .map(|ec| {
+                .map(|mut ec| {
                     ec.continuation = None;
                     ec
                 })
              }).from_err())
     }
 
-    pub fn stream_query_entities<T: DeserializeOwned>(
-        &self,
-        table_name: &str,
-        query: Option<&str>,
-    ) ->  impl Stream<Item = T, Error = AzureError> {
+    pub fn stream_query_entities<'a, T: DeserializeOwned + 'a>(
+        &'a self,
+        table_name: &'a str,
+        query: Option<&'a str>,
+    ) ->  impl Stream<Item = T, Error = AzureError> + 'a {
 
         stream::unfold(ContinuationState::Start, move |cont_state| {
             let cont = match cont_state {

--- a/azure_sdk_storage_table/src/table/mod.rs
+++ b/azure_sdk_storage_table/src/table/mod.rs
@@ -1,7 +1,7 @@
 mod batch;
 use self::batch::generate_batch_payload;
 pub use self::batch::BatchItem;
-use azure_sdk_core::errors::{check_status_extract_body, extract_status_and_body, AzureError, UnexpectedHTTPResult};
+use azure_sdk_core::errors::{check_status_extract_body, check_status_extract_headers_and_body, extract_status_and_body, AzureError, UnexpectedHTTPResult};
 use azure_sdk_storage_core::client::Client;
 use azure_sdk_storage_core::{get_default_json_mime, get_json_mime_nometadata, ServiceType};
 use futures::future::*;
@@ -13,6 +13,8 @@ use hyper::{
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use serde_json;
+use futures::Stream;
+use futures::stream;
 
 const TABLE_TABLES: &str = "TABLES";
 
@@ -94,6 +96,66 @@ impl TableService {
                     .and_then(|ec| ok(ec.value))
             })
         })
+    }
+
+    fn query_entity_collection<T: DeserializeOwned>(
+        &self,
+        table_name: &str,
+        query: Option<&str>,
+        continuation: Option<&Continuation>,
+    ) -> impl Future<Item = EntityCollection<T>, Error = AzureError> {
+        let mut path = table_name.to_owned();
+        path.push_str("?");
+        if let Some(clause) = query {
+            path.push_str(clause);
+        }
+        if let Some(cont) = continuation {
+            path.push_str("&NextPartitionKey=");
+            path.push_str(&cont.next_partition_key);
+            path.push_str("&NextRowKey=");
+            path.push_str(&cont.next_row_key);
+        }
+
+        let req = self.request_with_default_header(path.as_str(), &Method::GET, None);
+
+        done(req)
+            .from_err()
+            .and_then(move |future_response| check_status_extract_headers_and_body(future_response, StatusCode::OK))
+            .and_then(move |(headers, body)| done({
+                serde_json::from_slice::<EntityCollection<T>>(&body)
+                .map(|ec| {
+                    ec.continuation = None;
+                    ec
+                })
+             }).from_err())
+    }
+
+    pub fn stream_query_entities<T: DeserializeOwned>(
+        &self,
+        table_name: &str,
+        query: Option<&str>,
+    ) ->  impl Stream<Item = T, Error = AzureError> {
+
+        stream::unfold(ContinuationState::Start, move |cont_state| {
+            let cont = match cont_state {
+                ContinuationState::Start => None,
+                ContinuationState::Next(Some(cont)) => Some(cont),
+                ContinuationState::Next(None) => return None,
+            };
+
+            let mut path = table_name.to_owned();
+            if let Some(clause) = query {
+                path.push_str("?");
+                path.push_str(clause);
+            }
+
+            let req = self.query_entity_collection(table_name, query, cont.as_ref());
+
+            Some(req.map(move |ec| {
+                (stream::iter_ok(ec.value), ContinuationState::Next(ec.continuation))
+            }))
+        })
+        .flatten()
     }
 
     fn _prepare_insert_entity<T>(&self, table_name: &str, entity: &T) -> Result<ResponseFuture, AzureError>
@@ -214,6 +276,18 @@ struct TableEntity {
 #[derive(Deserialize)]
 struct EntityCollection<T> {
     value: Vec<T>,
+    #[serde(skip)]
+    continuation: Option<Continuation>,
+}
+
+struct Continuation {
+    next_partition_key: String,
+    next_row_key: String,
+}
+
+enum ContinuationState {
+    Start,
+    Next(Option<Continuation>),
 }
 
 #[inline]


### PR DESCRIPTION
I need to be able to stream the table query results #143. This is an attempt to add the function and support. I think I'm down to some lifetime errors and parsing the headers. 

3 lifetime errors look like this:
```
Camerons-MacBook-Pro:AzureSDKForRust cameron$ cargo build
   Compiling azure_sdk_storage_table v0.20.3 (/Users/cameron/rs/AzureSDKForRust/azure_sdk_storage_table)
error: cannot infer an appropriate lifetime
   --> azure_sdk_storage_table/src/table/mod.rs:139:50
    |
137 |       ) ->  impl Stream<Item = T, Error = AzureError> {
    |             ----------------------------------------- this return type evaluates to the `'static` lifetime...
138 | 
139 |           stream::unfold(ContinuationState::Start, move |cont_state| {
    |  __________________________________________________^
140 | |             let cont = match cont_state {
141 | |                 ContinuationState::Start => None,
142 | |                 ContinuationState::Next(Some(cont)) => Some(cont),
...   |
156 | |             }))
157 | |         })
    | |_________^ ...but this borrow...
    |
note: ...can't outlive the anonymous lifetime #2 defined on the method body at 133:5
   --> azure_sdk_storage_table/src/table/mod.rs:133:5
    |
133 | /     pub fn stream_query_entities<T: DeserializeOwned>(
134 | |         &self,
135 | |         table_name: &str,
136 | |         query: Option<&str>,
...   |
158 | |         .flatten()
159 | |     }
    | |_____^
help: you can add a constraint to the return type to make it last less than `'static` and match the anonymous lifetime #2 defined on the method body at 133:5
    |
137 |     ) ->  impl Stream<Item = T, Error = AzureError> + '_ {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```