### PR TITLE
Suggestions For Auth Async PR

### DIFF
--- a/azure_sdk_auth_aad/Cargo.toml
+++ b/azure_sdk_auth_aad/Cargo.toml
@@ -29,7 +29,7 @@ serde_derive         = "1.0.101"
 chrono               = "0.4.9"
 serde_json           = "1.0.41"
 log                  = "0.4.8"
-reqwest 	     = "0.10.0-alpha.1"
+reqwest 	     = { version = "0.10.0-alpha.1", features = ["json"] }
 
 [features]
 test_e2e           = []

--- a/azure_sdk_auth_aad/examples/interactive.rs
+++ b/azure_sdk_auth_aad/examples/interactive.rs
@@ -66,22 +66,4 @@ async fn main_async() {
         .unwrap();
 
     println!("\n\nresp {:?}", resp);
-
-    //let request = Request::builder()
-    //    .method("GET")
-    //    .header("Authorization", format!("Bearer {}", token.access_token().secret()))
-    //    //        .uri(format!("https://management.azure.com/subscriptions/{}/resourcegroups?api-version=2017-05-10", subscription_id))
-    //    .uri(format!(
-    //        "https://management.azure.com/subscriptions/{}/providers/Microsoft.Sql/servers?api-version=2015-05-01-preview",
-    //        subscription_id
-    //    ))
-    //    .body(Body::from(""))
-    //    .unwrap();
-
-    //let fut =
-    //    perform_http_request(&client, request, http::status::StatusCode::OK).and_then(|resp| {
-    //        println!("\n\nresp {:?}", resp);
-    //        ok(())
-    //    });
-    //core.run(fut).unwrap();
 }

--- a/azure_sdk_auth_aad/examples/non_interactive.rs
+++ b/azure_sdk_auth_aad/examples/non_interactive.rs
@@ -1,54 +1,55 @@
 use azure_sdk_auth_aad::*;
-use azure_sdk_core::perform_http_request;
-use futures::future::{ok, Future};
-use hyper::{Body, Client, Request};
 use oauth2::{ClientId, ClientSecret};
 use std::env;
 use std::sync::Arc;
-use tokio_core::reactor::Core;
+use url::Url;
+use futures::executor::block_on;
 
 fn main() {
+    block_on(main_async());
+}
+
+async fn main_async() {
     let client_id = ClientId::new(env::var("CLIENT_ID").expect("Missing CLIENT_ID environment variable."));
     let client_secret = ClientSecret::new(env::var("CLIENT_SECRET").expect("Missing CLIENT_SECRET environment variable."));
     let tenant_id = env::var("TENANT_ID").expect("Missing TENANT_ID environment variable.");
     let subscription_id = env::var("SUBSCRIPTION_ID").expect("Missing SUBSCRIPTION_ID environment variable.");
-
-    let mut core = Core::new().unwrap();
-    let client: Client<hyper_rustls::HttpsConnector<hyper::client::HttpConnector>> =
-        hyper::Client::builder().build(hyper_rustls::HttpsConnector::new(4));
-    let client = Arc::new(client);
-
+    
     // This Future will give you the final token to
     // use in authorization.
+    let client = Arc::new(reqwest::Client::new());
     let non_interactive = authorize_non_interactive(
         client.clone(),
         &client_id,
         &client_secret,
         "https://management.azure.com/",
         &tenant_id,
-    );
+    ).await;
 
-    let token = core.run(non_interactive).unwrap();
+    let token = non_interactive.unwrap();
     println!("Non interactive authorization == {:?}", token);
 
     // Let's enumerate the Azure SQL Databases instances
     // in the subscription. Note: this way of calling the REST API
     // will be different (and easier) using other Azure Rust SDK
     // crates, this is just an example.
-    let request = Request::builder()
-        .method("GET")
-        .header("Authorization", format!("Bearer {}", token.access_token().secret()))
-        //        .uri(format!("https://management.azure.com/subscriptions/{}/resourcegroups?api-version=2017-05-10", subscription_id))
-        .uri(format!(
+    let url = Url::parse(&format!(
             "https://management.azure.com/subscriptions/{}/providers/Microsoft.Sql/servers?api-version=2015-05-01-preview",
             subscription_id
-        ))
-        .body(Body::from(""))
+        )).unwrap();
+
+    let resp = reqwest::Client::new()
+        .get(url)
+        .header(
+            "Authorization",
+            format!("Bearer {}", token.access_token().secret()),
+        )
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
         .unwrap();
 
-    let fut = perform_http_request(&client, request, http::status::StatusCode::OK).and_then(|resp| {
-        println!("\n\nresp {:?}", resp);
-        ok(())
-    });
-    core.run(fut).unwrap();
+    println!("\n\nresp {:?}", resp);
 }

--- a/azure_sdk_auth_aad/src/login_response.rs
+++ b/azure_sdk_auth_aad/src/login_response.rs
@@ -1,6 +1,7 @@
 use azure_sdk_core::errors::AzureError;
 use chrono::{DateTime, TimeZone, Utc};
 use oauth2::AccessToken;
+use serde::de::{self, Deserialize, Deserializer};
 use std::str::FromStr;
 
 #[derive(Debug, Clone, Deserialize)]
@@ -46,6 +47,16 @@ impl FromStr for LoginResponse {
             resource: r.resource,
             access_token: AccessToken::new(r.access_token),
         })
+    }
+}
+
+impl<'de> Deserialize<'de> for LoginResponse {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        FromStr::from_str(&s).map_err(de::Error::custom)
     }
 }
 


### PR DESCRIPTION
* updated the `non_interactive` example as well
* dropped some extra unwrap -> wraps
* added a JSON deserialize impl for LoginResponse that just re-uses the `FromStr`, so you can call `.json()` on the login request 