### PR TITLE
Some helper struct to wrap a TableService and a table name.

### DIFF
--- a/azure_sdk_storage_table/src/table/mod.rs
+++ b/azure_sdk_storage_table/src/table/mod.rs
@@ -306,7 +306,7 @@ impl TableStorage {
         }
     }
 
-    pub fn create_table<T: Into<String>>(&self) -> impl Future<Item = (), Error = AzureError> {
+    pub fn create_table(&self) -> impl Future<Item = (), Error = AzureError> {
         self.service.create_table(self.table_name.clone())
     }
 


### PR DESCRIPTION
As I understand TableService is a thin wrapper around HttpClient (with extra connection related attributes). Thus making TableService Clone does not really effect performance.

Also I've added a new struct to wrap a TableService and a table_name (called TableStorage). In my usecase it's much easier to treat tables as distinct entitiey and it is not required to know is tables are located in the same storage account and use the same TableService.

(I hope the assumption that reusing the same TableSerice for multiple TableStorage is valid and causes no issue is correct).

And finally a related question: For now create_table returns 409 if the table already exists. I handle this in my client but I was wondering if it should be part of the API.

Also I'm open to any change if TableStorage should be created by TabelService that auto ignores 409:
```
impl TabelService {
async fn create_storage<S: Into<String>>(table_name: S) -> Result<TableStorage, AzureError> {...}
}
```
((( I'm using future 0.3 as you can see and I'm really waiting for the update :) )))

My current client code:
```
fn ignore_409(err: AzureError) -> Result<(), AzureError> {
    match err {
        AzureError::UnexpectedHTTPResult(e) if e.status_code() == 409 => Ok(()),
        e => Err(e),
    }
}

...
self.users.create_table().compat().await.or_else(ignore_409)?;
...
```
