### PR TITLE
Make Yes/No cloneable

### DIFF
--- a/azure_sdk_core/src/lib.rs
+++ b/azure_sdk_core/src/lib.rs
@@ -78,9 +78,9 @@ macro_rules! response_from_headers {
     };
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Yes;
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct No;
 
 pub trait ToAssign: Debug {}


### PR DESCRIPTION
So that structs that derive `Clone` and have a `Yes`/`No` type parameter can actually be cloned.