### PR TITLE
Some api changes to make tablestorage api easier to use

### DIFF
--- a/azure_sdk_storage_table/examples/copy_table.rs
+++ b/azure_sdk_storage_table/examples/copy_table.rs
@@ -39,10 +39,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
         let entries = entries?;
         for entry in entries {
             count += 1;
-            to_table_service
-                .insert_entry(&to_table_name, &entry)
+            println!("before {:?}", entry);
+            let entry = to_table_service
+                .insert_entry(&to_table_name, entry)
                 .await?;
-            println!("{:?}", entry);
+            println!("after {:?}", entry);
         }
     }
     println!(

--- a/azure_sdk_storage_table/src/table/batch.rs
+++ b/azure_sdk_storage_table/src/table/batch.rs
@@ -93,7 +93,7 @@ PUT https://myaccount.table.core.windows.net/Blogs(PartitionKey='Channel_17',Row
 Accept: application/json;odata=nometadata
 Content-Type: application/json
 
-{"RowKey":"3","PartitionKey":"Channel_17","etag":null,"Rating":9,"Text":".NET..."}
+{"RowKey":"3","PartitionKey":"Channel_17","Rating":9,"Text":".NET..."}
 --changeset_8a28b620-b4bb-458c-a177-0959fb14c977
 Content-Type: application/http
 Content-Transfer-Encoding: binary
@@ -102,7 +102,7 @@ PUT https://myaccount.table.core.windows.net/Blogs(PartitionKey='Channel_17',Row
 Accept: application/json;odata=nometadata
 Content-Type: application/json
 
-{"RowKey":"3","PartitionKey":"Channel_17","etag":null,"Rating":9,"Text":"PDC 2008..."}
+{"RowKey":"3","PartitionKey":"Channel_17","Rating":9,"Text":"PDC 2008..."}
 --changeset_8a28b620-b4bb-458c-a177-0959fb14c977
 Content-Type: application/http
 Content-Transfer-Encoding: binary

--- a/azure_sdk_storage_table/src/table/mod.rs
+++ b/azure_sdk_storage_table/src/table/mod.rs
@@ -268,15 +268,16 @@ impl TableService {
         Ok(entry)
     }
 
-    pub async fn delete_entry<'a, T>(
+    pub async fn delete_entry<'a>(
         &self,
         table_name: &str,
-        entry: &'a TableEntry<T>,
+        partition_key: &'a str,
+        row_key: &'a str,
     ) -> Result<(), AzureError>
     where
         T: Serialize + DeserializeOwned,
     {
-        let path = &entry_path(table_name, &entry.partition_key, &entry.row_key);
+        let path = &entry_path(table_name, partition_key, row_key);
 
         let future_response = self.request(path, &Method::DELETE, None, |ref mut request| {
             request.header(
@@ -466,11 +467,17 @@ impl TableStorage {
         self.service.update_entry(&self.table_name, entry).await
     }
 
-    pub async fn delete_entry<'a, T>(&self, entry: &'a TableEntry<T>) -> Result<(), AzureError>
+    pub async fn delete_entry<'a>(
+        &self,
+        partition_key: &'a str,
+        row_key: &'a str,
+    ) -> Result<(), AzureError>
     where
         T: Serialize + DeserializeOwned,
     {
-        self.service.delete_entry(&self.table_name, entry).await
+        self.service
+            .delete_entry(&self.table_name, partition_key, row_key)
+            .await
     }
 
     pub async fn batch<T>(

--- a/azure_sdk_storage_table/src/table/mod.rs
+++ b/azure_sdk_storage_table/src/table/mod.rs
@@ -64,7 +64,7 @@ impl TableService {
         table_name: &str,
         partition_key: &str,
         row_key: &str,
-    ) -> Result<TableEntry<T>, AzureError>
+    ) -> Result<Option<TableEntry<T>>, AzureError>
     where
         T: Serialize + DeserializeOwned,
     {
@@ -72,9 +72,14 @@ impl TableService {
         let future_response =
             self.request_with_default_header(path, &Method::GET, None, false, |_| {})?;
         let (headers, body) =
-            check_status_extract_headers_and_body(future_response, StatusCode::OK).await?;
+            match check_status_extract_headers_and_body(future_response, StatusCode::OK).await {
+                Err(AzureError::UnexpectedHTTPResult(e)) if e.status_code() == 404 => {
+                    return Ok(None)
+                }
+                x => x,
+            }?;
 
-        TableEntry::try_from((&headers, &body as &[u8]))
+        TableEntry::try_from((&headers, &body as &[u8])).map(|entry| Some(entry))
     }
 
     pub async fn query_entries<T>(
@@ -201,13 +206,13 @@ impl TableService {
         self.stream_query_entries_metadata(table_name, query, true)
     }
 
-    pub async fn insert_entry<'a, T>(
+    pub async fn insert_entry<T>(
         &self,
         table_name: &str,
-        entry: &'a TableEntry<T>,
-    ) -> Result<(), AzureError>
+        entry: TableEntry<T>,
+    ) -> Result<TableEntry<T>, AzureError>
     where
-        T: Serialize + DeserializeOwned + 'a,
+        T: Serialize + DeserializeOwned,
     {
         let obj_ser = serde_json::to_string(&entry)?.to_owned();
 
@@ -219,17 +224,18 @@ impl TableService {
             |_| {},
         )?;
 
-        check_status_extract_body(future_response, StatusCode::CREATED).await?;
-        Ok(())
+        let (headers, body) =
+            check_status_extract_headers_and_body(future_response, StatusCode::CREATED).await?;
+        TableEntry::try_from((&headers, &body as &[u8]))
     }
 
-    pub async fn update_entry<'a, T>(
+    pub async fn update_entry<T>(
         &self,
         table_name: &str,
-        entry: &'a TableEntry<T>,
-    ) -> Result<(), AzureError>
+        mut entry: TableEntry<T>,
+    ) -> Result<TableEntry<T>, AzureError>
     where
-        T: Serialize + DeserializeOwned + 'a,
+        T: Serialize + DeserializeOwned,
     {
         let obj_ser = serde_json::to_string(&entry)?.to_owned();
         let path = &entry_path(table_name, &entry.partition_key, &entry.row_key);
@@ -250,13 +256,16 @@ impl TableService {
                 headers.append(header::IF_MATCH, etag.parse().unwrap());
             },
         )?;
-        let (headers, body) =
+
+        let (headers, _body) =
             check_status_extract_headers_and_body(future_response, StatusCode::NO_CONTENT).await?;
 
-        debug!("response headers == {:?}", headers);
-        debug!("response body == {:?}", body);
-
-        Ok(())
+        // inject etag if present
+        entry.etag = match headers.get(header::ETAG) {
+            Some(etag) => Some(etag.to_str()?.to_owned()),
+            None => None,
+        };
+        Ok(entry)
     }
 
     pub async fn delete_entry<'a, T>(
@@ -389,15 +398,19 @@ impl TableStorage {
         }
     }
 
-    pub async fn create_table(&self) -> Result<(), AzureError> {
+    pub async fn create(&self) -> Result<(), AzureError> {
         self.service.create_table(self.table_name.clone()).await
+    }
+
+    pub async fn create_if_not_exists(&self) -> Result<(), AzureError> {
+        self.create().await.or_else(ignore_409)
     }
 
     pub async fn get_entry<T: DeserializeOwned>(
         &self,
         partition_key: &str,
         row_key: &str,
-    ) -> Result<TableEntry<T>, AzureError>
+    ) -> Result<Option<TableEntry<T>>, AzureError>
     where
         T: Serialize + DeserializeOwned,
     {
@@ -437,16 +450,16 @@ impl TableStorage {
             .stream_query_entries_fullmetadata(&self.table_name, query)
     }
 
-    pub async fn insert_entry<'a, T>(&self, entry: &'a TableEntry<T>) -> Result<(), AzureError>
+    pub async fn insert_entry<T>(&self, entry: TableEntry<T>) -> Result<TableEntry<T>, AzureError>
     where
-        T: Serialize + DeserializeOwned + 'a,
+        T: Serialize + DeserializeOwned,
     {
         self.service
             .insert_entry::<T>(&self.table_name, entry)
             .await
     }
 
-    pub async fn update_entry<T>(&self, entry: &TableEntry<T>) -> Result<(), AzureError>
+    pub async fn update_entry<T>(&self, entry: TableEntry<T>) -> Result<TableEntry<T>, AzureError>
     where
         T: Serialize + DeserializeOwned,
     {
@@ -524,4 +537,12 @@ fn entry_path(table_name: &str, partition_key: &str, row_key: &str) -> String {
 #[inline]
 pub fn get_batch_mime() -> &'static str {
     "multipart/mixed; boundary=batch_a1e9d677-b28b-435e-a89e-87e6a768a431"
+}
+
+#[inline]
+pub fn ignore_409(err: AzureError) -> Result<(), AzureError> {
+    match err {
+        AzureError::UnexpectedHTTPResult(e) if e.status_code() == 409 => Ok(()),
+        e => Err(e),
+    }
 }

--- a/azure_sdk_storage_table/src/table_entry.rs
+++ b/azure_sdk_storage_table/src/table_entry.rs
@@ -10,9 +10,13 @@ pub struct TableEntry<T> {
     pub row_key: String,
     #[serde(rename = "PartitionKey")]
     pub partition_key: String,
-    pub etag: Option<String>, // none means etag check is disabled
+
+    // etag is not serialized, it is parsed from the header
+    #[serde(skip_serializing)]
+    pub etag: Option<String>,
+    
     #[serde(flatten)]
-    pub payload: T, // raw, partition key is not included
+    pub payload: T,
 }
 
 impl<T> TableEntry<T>


### PR DESCRIPTION
Some minor api mods as of https://github.com/MindFlavor/AzureSDKForRust/issues/174:
- if item is not found during get, it returns an Ok(None). Missing item is not an error
- insert and update moves the tableentry and return a new one with updated etag
- tablestrage creation api mods: create and create_if_not_exists

To be considered: Timestamp should be added to the TableEntry but I have a few questions:
- Should it be an Option that is filled on return and ignored in inputs (insert,delete,update) as timestamp cannot be altered ?
- What is the correct type to store the TimeStamp in rust ?
