### PR TITLE
Draft: Workarounds for Azurite Creation Dates

### DIFF
--- a/azure_sdk_core/src/parsing.rs
+++ b/azure_sdk_core/src/parsing.rs
@@ -40,9 +40,13 @@ impl FromStringOptional<chrono::DateTime<chrono::Utc>> for chrono::DateTime<chro
 
 #[inline]
 pub fn from_azure_time(s: &str) -> Result<chrono::DateTime<chrono::Utc>, chrono::ParseError> {
-    let dt = chrono::DateTime::parse_from_rfc2822(s)?;
-    let dt_utc: chrono::DateTime<chrono::Utc> = dt.with_timezone(&chrono::Utc);
-    Ok(dt_utc)
+    if let Ok(dt) = chrono::DateTime::parse_from_rfc2822(s) {
+        let dt_utc: chrono::DateTime<chrono::Utc> = dt.with_timezone(&chrono::Utc);
+        Ok(dt_utc)
+    } else {
+        log::warn!("Received an invalid date: {}, returning now()", s);
+        Ok(chrono::Utc::now())
+    }
 }
 
 #[inline]

--- a/azure_sdk_storage_blob/src/blob/mod.rs
+++ b/azure_sdk_storage_blob/src/blob/mod.rs
@@ -46,6 +46,19 @@ use azure_sdk_core::{
     BlobNameRequired, ContainerNameRequired,
 };
 
+fn get_creation_time(h: &header::HeaderMap) -> Result<Option<DateTime<Utc>>, AzureError> {
+    if let Some(creation_time) = h.get(CREATION_TIME) {
+        // Check that the creation time is valid
+        let creation_time = creation_time.to_str()?;
+        let creation_time = DateTime::parse_from_rfc2822(creation_time)?;
+        let creation_time = DateTime::from_utc(creation_time.naive_utc(), Utc);
+        Ok(Some(creation_time))
+    } else {
+        // Not having a creation time is ok
+        Ok(None)
+    }
+}
+
 pub trait BlockListTypeSupport {
     type O;
     fn with_block_list_type(self, block_list_type: BlockListType) -> Self::O;
@@ -100,7 +113,7 @@ pub struct Blob {
     pub name: String,
     pub container_name: String,
     pub snapshot_time: Option<DateTime<Utc>>,
-    pub creation_time: DateTime<Utc>,
+    pub creation_time: Option<DateTime<Utc>>,
     pub last_modified: Option<DateTime<Utc>>, // optional because unavailable in uncommitted blobs
     pub etag: Option<String>,                 // optional because unavailable in uncommitted blobs
     pub content_length: u64,
@@ -135,7 +148,7 @@ impl Blob {
     pub(crate) fn parse(elem: &Element, container_name: &str) -> Result<Blob, AzureError> {
         let name = cast_must::<String>(elem, &["Name"])?;
         let snapshot_time = cast_optional::<DateTime<Utc>>(elem, &["Snapshot"])?;
-        let creation_time = cast_must::<DateTime<Utc>>(elem, &["Properties", "Creation-Time"])?;
+        let creation_time = cast_optional::<DateTime<Utc>>(elem, &["Properties", "Creation-Time"])?;
         let last_modified = cast_optional::<DateTime<Utc>>(elem, &["Properties", "Last-Modified"])?;
         let etag = cast_optional::<String>(elem, &["Properties", "Etag"])?;
 
@@ -258,12 +271,8 @@ impl Blob {
     ) -> Result<Blob, AzureError> {
         trace!("\n{:?}", h);
 
-        let creation_time = h
-            .get(CREATION_TIME)
-            .ok_or_else(|| AzureError::HeaderNotFound(CREATION_TIME.to_owned()))?
-            .to_str()?;
-        let creation_time = DateTime::parse_from_rfc2822(creation_time)?;
-        let creation_time = DateTime::from_utc(creation_time.naive_utc(), Utc);
+        let creation_time = get_creation_time(h)?;
+
         trace!("creation_time == {:?}", creation_time);
 
         let content_type = h


### PR DESCRIPTION
When working with Azurite, I found another problem: creation dates seem to work in a way that this client doesn't expect.
Sometimes they are missing (eg. from headers) and other times they're malformed in some way (eg. in `from_azure_time`).

This workaround works for my project as I don't need the creation date, but I'm opening the PR as a draft because I'm not sure if this is the right solution, or even if it's actually Azurite that is broken 🤔 
