### PR TITLE
Update service bus peek lock method to accept timeout

### DIFF
--- a/azure_sdk_core/src/errors.rs
+++ b/azure_sdk_core/src/errors.rs
@@ -386,6 +386,20 @@ pub async fn extract_status_and_body(
 }
 
 #[inline]
+pub async fn extract_location_status_and_body(
+    resp: hyper::client::ResponseFuture,
+) -> Result<(http::StatusCode, String, String), AzureError> {
+    let res = resp.await?;
+    let status = res.status();
+    let location: String = match res.headers().get("Location") {
+        Some(header_value) => header_value.to_str()?.to_owned(),
+        _ => "".to_owned(),
+    };
+    let body = body::to_bytes(res.into_body()).await?;
+    Ok((status, location, str::from_utf8(&body)?.to_owned()))
+}
+
+#[inline]
 pub async fn check_status_extract_body(
     resp: hyper::client::ResponseFuture,
     expected_status_code: hyper::StatusCode,

--- a/azure_sdk_service_bus/src/event_hub/client.rs
+++ b/azure_sdk_service_bus/src/event_hub/client.rs
@@ -1,5 +1,6 @@
 use crate::event_hub::{
-    delete_message, peek_lock, receive_and_delete, renew_lock, send_event, unlock_message,
+    delete_message, peek_lock, peek_lock_with_location, receive_and_delete, renew_lock, send_event,
+    unlock_message,
 };
 use azure_sdk_core::errors::AzureError;
 use hyper_rustls::HttpsConnector;
@@ -64,6 +65,23 @@ impl Client {
         timeout: Option<Duration>,
     ) -> Result<String, AzureError> {
         peek_lock(
+            &self.http_client,
+            &self.namespace,
+            &self.event_hub,
+            &self.policy_name,
+            &self.signing_key,
+            duration,
+            timeout,
+        )
+        .await
+    }
+
+    pub async fn peek_lock_with_location(
+        &mut self,
+        duration: Duration,
+        timeout: Option<Duration>,
+    ) -> Result<(http::StatusCode, String, String), AzureError> {
+        peek_lock_with_location(
             &self.http_client,
             &self.namespace,
             &self.event_hub,

--- a/azure_sdk_service_bus/src/event_hub/client.rs
+++ b/azure_sdk_service_bus/src/event_hub/client.rs
@@ -1,6 +1,6 @@
 use crate::event_hub::{
-    delete_message, peek_lock, peek_lock_with_location, receive_and_delete, renew_lock, send_event,
-    unlock_message,
+    delete_message, peek_lock, peek_lock_full, receive_and_delete, renew_lock, send_event,
+    unlock_message, PeekLockResponse,
 };
 use azure_sdk_core::errors::AzureError;
 use hyper_rustls::HttpsConnector;
@@ -76,12 +76,12 @@ impl Client {
         .await
     }
 
-    pub async fn peek_lock_with_location(
+    pub async fn peek_lock_full(
         &mut self,
         duration: Duration,
         timeout: Option<Duration>,
-    ) -> Result<(http::StatusCode, String, String), AzureError> {
-        peek_lock_with_location(
+    ) -> Result<PeekLockResponse, AzureError> {
+        peek_lock_full(
             &self.http_client,
             &self.namespace,
             &self.event_hub,

--- a/azure_sdk_service_bus/src/event_hub/client.rs
+++ b/azure_sdk_service_bus/src/event_hub/client.rs
@@ -58,7 +58,11 @@ impl Client {
         .await
     }
 
-    pub async fn peek_lock(&mut self, duration: Duration) -> Result<String, AzureError> {
+    pub async fn peek_lock(
+        &mut self,
+        duration: Duration,
+        timeout: Option<Duration>,
+    ) -> Result<String, AzureError> {
         peek_lock(
             &self.http_client,
             &self.namespace,
@@ -66,6 +70,7 @@ impl Client {
             &self.policy_name,
             &self.signing_key,
             duration,
+            timeout,
         )
         .await
     }

--- a/azure_sdk_service_bus/src/event_hub/mod.rs
+++ b/azure_sdk_service_bus/src/event_hub/mod.rs
@@ -96,7 +96,7 @@ async fn peek_lock(
     check_status_extract_body(req?, StatusCode::CREATED).await
 }
 
-async fn peek_lock_with_location(
+async fn peek_lock_full(
     http_client: &HttpClient,
     namespace: &str,
     event_hub: &str,
@@ -104,7 +104,7 @@ async fn peek_lock_with_location(
     hmac: &hmac::Key,
     duration: Duration,
     timeout: Option<Duration>,
-) -> Result<(StatusCode, String, String), AzureError> {
+) -> Result<PeekLockResponse, AzureError> {
     let req = peek_lock_prepare(
         http_client,
         namespace,
@@ -115,7 +115,47 @@ async fn peek_lock_with_location(
         timeout,
     );
 
-    extract_location_status_and_body(req?).await
+    let a = extract_location_status_and_body(req?).await?;
+
+    Ok(PeekLockResponse {
+        http_client: http_client.to_owned(),
+        status: a.0,
+        delete_location: a.1,
+        body: a.2,
+        duration: duration.clone(),
+        policy_name: policy_name.to_owned(),
+        signing_key: hmac.to_owned(),
+    })
+}
+
+pub struct PeekLockResponse {
+    http_client: HttpClient,
+    status: StatusCode,
+    delete_location: String,
+    body: String,
+    policy_name: String,
+    signing_key: hmac::Key,
+    duration: Duration,
+}
+
+impl PeekLockResponse {
+    pub fn body(&self) -> String {
+        self.body.clone()
+    }
+    pub fn status(&self) -> StatusCode {
+        self.status
+    }
+    pub async fn delete_message(&self) -> Result<String, AzureError> {
+        let req = delete_message_get_request(
+            &self.http_client,
+            &self.policy_name,
+            &self.signing_key,
+            self.duration,
+            self.delete_location.clone(),
+        );
+
+        check_status_extract_body(req?, StatusCode::OK).await
+    }
 }
 
 fn receive_and_delete_prepare(
@@ -182,6 +222,17 @@ fn delete_message_prepare(
     debug!("url == {:?}", url);
 
     // generate sas signature based on key name, key value, url and duration.
+
+    delete_message_get_request(http_client, policy_name, signing_key, duration, url)
+}
+
+fn delete_message_get_request(
+    http_client: &HttpClient,
+    policy_name: &str,
+    signing_key: &hmac::Key,
+    duration: Duration,
+    url: String,
+) -> Result<hyper::client::ResponseFuture, AzureError> {
     let sas = generate_signature(policy_name, signing_key, &url, duration);
     debug!("sas == {}", sas);
 

--- a/azure_sdk_service_bus/src/event_hub/mod.rs
+++ b/azure_sdk_service_bus/src/event_hub/mod.rs
@@ -66,6 +66,7 @@ fn peek_lock_prepare(
 
     let request = hyper::Request::post(url.into_string())
         .header(header::AUTHORIZATION, sas)
+        .header(header::CONTENT_LENGTH, 0)
         .body(Body::empty())?;
 
     Ok(http_client.request(request))

--- a/azure_sdk_service_bus/src/event_hub/mod.rs
+++ b/azure_sdk_service_bus/src/event_hub/mod.rs
@@ -1,4 +1,6 @@
-use azure_sdk_core::errors::{check_status_extract_body, AzureError};
+use azure_sdk_core::errors::{
+    check_status_extract_body, extract_location_status_and_body, AzureError,
+};
 use hyper::{self, header, Body, StatusCode};
 use hyper_rustls::HttpsConnector;
 use ring::hmac;
@@ -92,6 +94,28 @@ async fn peek_lock(
     );
 
     check_status_extract_body(req?, StatusCode::CREATED).await
+}
+
+async fn peek_lock_with_location(
+    http_client: &HttpClient,
+    namespace: &str,
+    event_hub: &str,
+    policy_name: &str,
+    hmac: &hmac::Key,
+    duration: Duration,
+    timeout: Option<Duration>,
+) -> Result<(StatusCode, String, String), AzureError> {
+    let req = peek_lock_prepare(
+        http_client,
+        namespace,
+        event_hub,
+        policy_name,
+        hmac,
+        duration,
+        timeout,
+    );
+
+    extract_location_status_and_body(req?).await
 }
 
 fn receive_and_delete_prepare(


### PR DESCRIPTION
This extension of the library is a mob effort from
- @TimboTambo
- @rjkerrison
- @craiga
- @pataruco 
- @StuartHarris
- @m-doughty

We are enabling `peek_lock` to handle timeout params for lock duration

We are aiming to:
- [ ] Write unit tests
- [ ] Write documentation