### PR TITLE
Try to parse into a known error on fail.

### DIFF
--- a/azure_sdk_auth_aad/src/errors.rs
+++ b/azure_sdk_auth_aad/src/errors.rs
@@ -13,3 +13,13 @@ pub enum ServerReceiveError {
         received_state_secret: String,
     },
 }
+
+#[derive(Debug, Fail, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ErrorResponse {
+    #[fail(
+        display = "Unrecognized Azure error response:\n{}\n",
+        error_description
+    )]
+    GenericError { error_description: String },
+}


### PR DESCRIPTION
Get the body text and try to parse into a login response.
If that fails try to parse the body to get an `error_description` from
Azure. If that fails report whatever the original issue was with parsing
the response as the error.

`ErrorResponse` could be expanded on to recognize the `error` field and
give more useful info. Not sure what connecting `ErrorResponse` to
`AzureError` in a nice way looks like, but this leaves all the
interfaces the same for now.