### PR TITLE
Add `azure_sas` associated function to `TableClient`

### DIFF
--- a/azure_sdk_storage_table/src/table_client.rs
+++ b/azure_sdk_storage_table/src/table_client.rs
@@ -26,9 +26,17 @@ pub struct TableClient {
 }
 
 impl TableClient {
+    /// Create a new `TableClient` using a key.
     pub fn new(account: &str, key: &str) -> Result<Self, AzureError> {
         Ok(TableClient {
             client: Client::new(account, key)?,
+        })
+    }
+
+    /// Create a new `TableClient` using a SAS token.
+    pub fn azure_sas(account: &str, sas_token: &str) -> Result<Self, AzureError> {
+        Ok(TableClient {
+            client: Client::azure_sas(account, sas_token)?,
         })
     }
 


### PR DESCRIPTION
This allows a TableClient to be created from a SAS token as well as from
an account key. This was possible using the old TableStorage API since an `azure_sdk_storage_core::client::Client` was used directly instead of a wrapper type, so this commit just adds the functionality back in.