### PR TITLE
Improve macros

### DIFF
--- a/azure_sdk_core/src/enumerations.rs
+++ b/azure_sdk_core/src/enumerations.rs
@@ -25,29 +25,29 @@ macro_rules! create_enum {
             }
         }
 
-        impl FromStringOptional<$en> for $en {
-            fn from_str_optional(s : &str) -> Result<$en, TraversingError> {
+        impl $crate::parsing::FromStringOptional<$en> for $en {
+            fn from_str_optional(s : &str) -> Result<$en, $crate::errors::TraversingError> {
                 match s.parse::<$en>() {
-                    Err(e) => Err(TraversingError::ParsingError(e)),
+                    Err(e) => Err($crate::errors::TraversingError::ParsingError(e)),
                     Ok(v) => Ok(v)
                 }
             }
         }
 
-        impl FromStr for $en {
-            type Err = enumerations::ParsingError;
+        impl ::std::str::FromStr for $en {
+            type Err = $crate::enumerations::ParsingError;
 
-            fn from_str(s: &str) -> Result<$en, enumerations::ParsingError> {
+            fn from_str(s: &str) -> Result<$en, $crate::enumerations::ParsingError> {
                 match s {
                     $(
                         $x => Ok($en::$na),
                     )*
-                    _ => Err(enumerations::ParsingError::ElementNotFound(s.to_owned())),
+                    _ => Err($crate::enumerations::ParsingError::ElementNotFound(s.to_owned())),
                 }
             }
         }
 
-        impl AsRef<str> for $en {
+        impl ::std::convert::AsRef<str> for $en {
             fn as_ref(&self) -> &str {
                  match *self {
                     $(
@@ -57,8 +57,8 @@ macro_rules! create_enum {
             }
         }
 
-        impl fmt::Display for $en {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        impl ::std::fmt::Display for $en {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
                 match *self {
                     $(
                         $en::$na => write!(f, "{}", $x),
@@ -71,12 +71,6 @@ macro_rules! create_enum {
 
 #[cfg(test)]
 mod test {
-    use crate::enumerations;
-    use crate::errors::TraversingError;
-    use crate::parsing::FromStringOptional;
-    use std::fmt;
-    use std::str::FromStr;
-
     create_enum!(Colors, (Black, "Black"), (White, "White"), (Red, "Red"));
     create_enum!(ColorsMonochrome, (Black, "Black"), (White, "White"));
 

--- a/azure_sdk_core/src/lease.rs
+++ b/azure_sdk_core/src/lease.rs
@@ -1,8 +1,3 @@
-use crate::enumerations;
-use crate::errors::TraversingError;
-use crate::parsing::FromStringOptional;
-use std::fmt;
-use std::str::FromStr;
 use uuid::Uuid;
 
 create_enum!(LeaseStatus, (Locked, "locked"), (Unlocked, "unlocked"));

--- a/azure_sdk_core/src/lib.rs
+++ b/azure_sdk_core/src/lib.rs
@@ -63,7 +63,7 @@ macro_rules! response_from_headers {
         }
 
         impl $cn {
-            pub(crate) fn from_headers(headers: &HeaderMap) -> Result<$cn, AzureError> {
+            pub(crate) fn from_headers(headers: &HeaderMap) -> Result<$cn, $crate::errors::AzureError> {
                $(
                     let $na = $fh(headers)?;
                 )+

--- a/azure_sdk_core/src/lib.rs
+++ b/azure_sdk_core/src/lib.rs
@@ -21,8 +21,6 @@ pub mod ba512_range;
 use base64::encode;
 pub mod modify_conditions;
 use self::modify_conditions::{IfMatchCondition, IfSinceCondition, SequenceNumberCondition};
-use std::fmt;
-use std::str::FromStr;
 pub mod headers;
 pub mod range;
 use self::headers::{
@@ -39,9 +37,8 @@ use hyper::header::{
 use uuid::Uuid;
 pub type RequestId = Uuid;
 pub type SessionToken = String;
-use crate::errors::{check_status_extract_body_2, AzureError, TraversingError};
+use crate::errors::{check_status_extract_body_2, AzureError};
 use crate::lease::LeaseId;
-use crate::parsing::FromStringOptional;
 use http::request::Builder;
 use http::HeaderMap;
 use std::collections::HashMap;

--- a/azure_sdk_storage_blob/src/blob/mod.rs
+++ b/azure_sdk_storage_blob/src/blob/mod.rs
@@ -28,18 +28,17 @@ use chrono::{DateTime, Utc};
 use hyper::header;
 use std::borrow::Borrow;
 use std::collections::HashMap;
-use std::{fmt, str::FromStr};
+use std::{str::FromStr};
 use url::form_urlencoded;
 use xml::Element;
 use xml::Xml::ElementNode;
 
 use azure_sdk_core::{
-    enumerations,
     errors::{AzureError, TraversingError},
     incompletevector::IncompleteVector,
     lease::{LeaseDuration, LeaseState, LeaseStatus},
     parsing::{
-        cast_must, cast_optional, from_azure_time, inner_text, traverse, FromStringOptional,
+        cast_must, cast_optional, from_azure_time, inner_text, traverse,
     },
     range::Range,
     util::HeaderMapExt,

--- a/azure_sdk_storage_blob/src/blob/responses/acquire_blob_lease_response.rs
+++ b/azure_sdk_storage_blob/src/blob/responses/acquire_blob_lease_response.rs
@@ -1,4 +1,3 @@
-use azure_sdk_core::errors::AzureError;
 use azure_sdk_core::lease::LeaseId;
 use azure_sdk_core::RequestId;
 use chrono::{DateTime, Utc};

--- a/azure_sdk_storage_blob/src/blob/responses/break_blob_lease_response.rs
+++ b/azure_sdk_storage_blob/src/blob/responses/break_blob_lease_response.rs
@@ -1,4 +1,3 @@
-use azure_sdk_core::errors::AzureError;
 use azure_sdk_core::RequestId;
 use chrono::{DateTime, Utc};
 

--- a/azure_sdk_storage_blob/src/blob/responses/change_blob_lease_response.rs
+++ b/azure_sdk_storage_blob/src/blob/responses/change_blob_lease_response.rs
@@ -1,4 +1,3 @@
-use azure_sdk_core::errors::AzureError;
 use azure_sdk_core::lease::LeaseId;
 use azure_sdk_core::RequestId;
 use chrono::{DateTime, Utc};

--- a/azure_sdk_storage_blob/src/blob/responses/clear_page_response.rs
+++ b/azure_sdk_storage_blob/src/blob/responses/clear_page_response.rs
@@ -1,4 +1,3 @@
-use azure_sdk_core::errors::AzureError;
 use azure_sdk_core::RequestId;
 use chrono::{DateTime, Utc};
 

--- a/azure_sdk_storage_blob/src/blob/responses/delete_blob_response.rs
+++ b/azure_sdk_storage_blob/src/blob/responses/delete_blob_response.rs
@@ -1,4 +1,3 @@
-use azure_sdk_core::errors::AzureError;
 use azure_sdk_core::RequestId;
 use chrono::{DateTime, Utc};
 

--- a/azure_sdk_storage_blob/src/blob/responses/release_blob_lease_response.rs
+++ b/azure_sdk_storage_blob/src/blob/responses/release_blob_lease_response.rs
@@ -1,4 +1,3 @@
-use azure_sdk_core::errors::AzureError;
 use azure_sdk_core::RequestId;
 use chrono::{DateTime, Utc};
 

--- a/azure_sdk_storage_blob/src/blob/responses/renew_blob_lease_response.rs
+++ b/azure_sdk_storage_blob/src/blob/responses/renew_blob_lease_response.rs
@@ -1,4 +1,3 @@
-use azure_sdk_core::errors::AzureError;
 use azure_sdk_core::lease::LeaseId;
 use azure_sdk_core::RequestId;
 use chrono::{DateTime, Utc};

--- a/azure_sdk_storage_blob/src/container/mod.rs
+++ b/azure_sdk_storage_blob/src/container/mod.rs
@@ -2,14 +2,13 @@ pub mod requests;
 pub mod responses;
 
 use azure_sdk_core::{
-    enumerations,
-    errors::{AzureError, TraversingError},
+    errors::{AzureError},
     headers::{
         BLOB_PUBLIC_ACCESS, HAS_IMMUTABILITY_POLICY, HAS_LEGAL_HOLD, LEASE_DURATION, LEASE_STATE,
         LEASE_STATUS, META_PREFIX,
     },
     lease::{LeaseDuration, LeaseState, LeaseStatus},
-    parsing::{cast_must, cast_optional, traverse, FromStringOptional},
+    parsing::{cast_must, cast_optional, traverse},
     ContainerNameRequired,
 };
 use azure_sdk_storage_core::ClientRequired;
@@ -19,7 +18,7 @@ use http::HeaderMap;
 use hyper::header;
 use hyper::header::HeaderName;
 use std::collections::HashMap;
-use std::{fmt, str::FromStr};
+use std::str::FromStr;
 use url::form_urlencoded;
 use xml::{Element, Xml};
 

--- a/azure_sdk_storage_blob/src/container/responses/acquire_lease_response.rs
+++ b/azure_sdk_storage_blob/src/container/responses/acquire_lease_response.rs
@@ -1,4 +1,3 @@
-use azure_sdk_core::errors::AzureError;
 use azure_sdk_core::lease::LeaseId;
 use azure_sdk_core::RequestId;
 use chrono::{DateTime, Utc};

--- a/azure_sdk_storage_blob/src/container/responses/break_lease_response.rs
+++ b/azure_sdk_storage_blob/src/container/responses/break_lease_response.rs
@@ -1,4 +1,3 @@
-use azure_sdk_core::errors::AzureError;
 use azure_sdk_core::RequestId;
 use chrono::{DateTime, Utc};
 

--- a/azure_sdk_storage_blob/src/container/responses/release_lease_response.rs
+++ b/azure_sdk_storage_blob/src/container/responses/release_lease_response.rs
@@ -1,4 +1,3 @@
-use azure_sdk_core::errors::AzureError;
 use azure_sdk_core::RequestId;
 use chrono::{DateTime, Utc};
 


### PR DESCRIPTION
Fully qualify imports in the macro, to ensure no imports are needed when using it.
Previously users would get surprises when using the macro, as it would fail to compile if the right imports weren't defined.