### PR TITLE
Update serde-xml-rs dependency to 0.4 (from 0.3)

### DIFF
--- a/azure_sdk_core/Cargo.toml
+++ b/azure_sdk_core/Cargo.toml
@@ -30,7 +30,7 @@ quick-error             = "1.2"
 serde                   = "1.0"
 serde_derive            = "1.0"
 serde_json              = "1.0"
-serde-xml-rs            = "0.3"
+serde-xml-rs            = "0.4"
 time                    = "0.1"
 url                     = "2.1"
 uuid                    = { version = "0.8", features = ["v4"] }

--- a/azure_sdk_cosmos/Cargo.toml
+++ b/azure_sdk_cosmos/Cargo.toml
@@ -31,7 +31,7 @@ quick-error              = "1.2"
 serde                    = "1.0"
 serde_derive             = "1.0"
 serde_json               = "1.0"
-serde-xml-rs             = "0.3"
+serde-xml-rs             = "0.4"
 time                     = "0.1"
 url                      = "2.1"
 uuid                     = { version = "0.8", features = ["v4"] }

--- a/azure_sdk_service_bus/Cargo.toml
+++ b/azure_sdk_service_bus/Cargo.toml
@@ -29,7 +29,7 @@ quick-error          = "1.2"
 serde                = "1.0"
 serde_derive         = "1.0"
 serde_json           = "1.0"
-serde-xml-rs         = "0.3"
+serde-xml-rs         = "0.4"
 time                 = "0.1"
 url                  = "2.1"
 uuid                 = { version = "0.8", features = ["v4"] }

--- a/azure_sdk_storage_account/Cargo.toml
+++ b/azure_sdk_storage_account/Cargo.toml
@@ -32,7 +32,7 @@ quick-error              = "1.2"
 serde                    = "1.0"
 serde_derive             = "1.0"
 serde_json               = "1.0"
-serde-xml-rs             = "0.3"
+serde-xml-rs             = "0.4"
 time                     = "0.1"
 url                      = "2.1"
 uuid                     = { version = "0.8", features = ["v4"] }

--- a/azure_sdk_storage_blob/Cargo.toml
+++ b/azure_sdk_storage_blob/Cargo.toml
@@ -32,7 +32,7 @@ quick-error             = "1.2"
 serde                   = "1.0"
 serde_derive            = "1.0"
 serde_json              = "1.0"
-serde-xml-rs            = "0.3"
+serde-xml-rs            = "0.4"
 time                    = "0.1"
 url                     = "2.1"
 uuid                    = { version = "0.8", features = ["v4"] }

--- a/azure_sdk_storage_core/Cargo.toml
+++ b/azure_sdk_storage_core/Cargo.toml
@@ -31,7 +31,7 @@ quick-error             = "1.2"
 serde                   = "1.0"
 serde_derive            = "1.0"
 serde_json              = "1.0"
-serde-xml-rs            = "0.3"
+serde-xml-rs            = "0.4"
 time                    = "0.1"
 url                     = "2.1"
 uuid                    = { version = "0.8", features = ["v4"] }

--- a/azure_sdk_storage_table/Cargo.toml
+++ b/azure_sdk_storage_table/Cargo.toml
@@ -30,7 +30,7 @@ quick-error            = "1.2"
 serde                  = "1.0"
 serde_derive           = "1.0"
 serde_json             = "1.0"
-serde-xml-rs           = "0.3"
+serde-xml-rs           = "0.4"
 time                   = "0.1"
 url                    = "2.1"
 uuid                   = { version = "0.8", features = ["v4"] }


### PR DESCRIPTION
This should remove `error-chain` from the dependency tree, allowing an `AzureError` that is `Sync`.

See #259 and #260.