### PR TITLE
Azure AAD: Exchange refresh token support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [![Build Status](https://travis-ci.org/MindFlavor/AzureSDKForRust.svg?branch=master)](https://travis-ci.org/MindFlavor/AzureSDKForRust) [![Coverage Status](https://coveralls.io/repos/MindFlavor/AzureSDKForRust/badge.svg?branch=master&service=github)](https://coveralls.io/github/MindFlavor/AzureSDKForRust?branch=master) ![stability-unstable](https://img.shields.io/badge/stability-unstable-yellow.svg)
 
-[![tag](https://img.shields.io/github/tag/mindflavor/AzureSDKForRust.svg)](https://github.com/MindFlavor/AzureSDKForRust/tree/aad_0.45.1) [![release](https://img.shields.io/github/release/mindflavor/AzureSDKForRust.svg)](https://github.com/MindFlavor/AzureSDKForRust/releases/tag/aad_0.45.1) [![commitssince](https://img.shields.io/github/commits-since/mindflavor/AzureSDKForRust/aad_0.45.1)](https://github.com/MindFlavor/AzureSDKForRust/commits/master)
+[![tag](https://img.shields.io/github/tag/mindflavor/AzureSDKForRust.svg)](https://github.com/MindFlavor/AzureSDKForRust/tree/aad_0.46.0) [![release](https://img.shields.io/github/release/mindflavor/AzureSDKForRust.svg)](https://github.com/MindFlavor/AzureSDKForRust/releases/tag/aad_0.46.0) [![commitssince](https://img.shields.io/github/commits-since/mindflavor/AzureSDKForRust/aad_0.46.0)](https://github.com/MindFlavor/AzureSDKForRust/commits/master)
 
 [![GitHub contributors](https://img.shields.io/github/contributors/MindFlavor/AzureSDKForRust.svg)](https://github.com/MindFlavor/AzureSDKForRust/graphs/contributors)
 

--- a/azure_sdk_auth_aad/examples/device_code_flow.rs
+++ b/azure_sdk_auth_aad/examples/device_code_flow.rs
@@ -5,7 +5,6 @@ use futures::stream::StreamExt;
 use oauth2::ClientId;
 use std::env;
 use std::error::Error;
-use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
@@ -31,7 +30,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         &client_id,
         &[
             &format!(
-                "https://{}.blob.core.windows.net/.default",
+                "https://{}.blob.core.windows.net/user_impersonation",
                 storage_account_name
             ),
             "offline_access",
@@ -49,7 +48,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // return, besides errors, a success meaning either
     // Success or Pending. The loop will continue until we
     // get either a Success or an error.
-    let mut stream = Box::pin(device_code_flow.stream(&client));
+    let mut stream = Box::pin(device_code_flow.stream());
     let mut authorization = None;
     while let Some(resp) = stream.next().await {
         println!("{:?}", resp);

--- a/azure_sdk_auth_aad/src/lib.rs
+++ b/azure_sdk_auth_aad/src/lib.rs
@@ -23,10 +23,13 @@ pub mod errors;
 mod refresh_token;
 pub use refresh_token::*;
 mod naive_server;
+mod traits;
 pub use crate::device_code_flow::*;
 pub use crate::device_code_responses::*;
 use futures::TryFutureExt;
+mod responses;
 pub use naive_server::naive_server;
+mod prelude;
 
 #[derive(Debug)]
 pub struct AuthObj {

--- a/azure_sdk_auth_aad/src/prelude.rs
+++ b/azure_sdk_auth_aad/src/prelude.rs
@@ -1,0 +1,1 @@
+pub use crate::traits::*;

--- a/azure_sdk_auth_aad/src/responses/mod.rs
+++ b/azure_sdk_auth_aad/src/responses/mod.rs
@@ -1,0 +1,2 @@
+mod refresh_token_response;
+pub use refresh_token_response::RefreshTokenResponse;

--- a/azure_sdk_auth_aad/src/responses/refresh_token_response.rs
+++ b/azure_sdk_auth_aad/src/responses/refresh_token_response.rs
@@ -1,0 +1,67 @@
+use crate::prelude::*;
+use oauth2::AccessToken;
+use std::convert::TryInto;
+
+#[derive(Debug, Clone)]
+pub struct RefreshTokenResponse {
+    token_type: String,
+    scopes: Vec<String>,
+    expires_in: u64,
+    ext_expires_in: u64,
+    access_token: AccessToken,
+    refresh_token: AccessToken,
+}
+
+impl TryInto<RefreshTokenResponse> for String {
+    type Error = serde_json::Error;
+
+    fn try_into(self) -> Result<RefreshTokenResponse, Self::Error> {
+        // we use a temp struct to deserialize the scope into
+        // the scopes vec at later time
+        #[derive(Debug, Clone, Deserialize)]
+        pub struct _RefreshTokenResponse<'a> {
+            token_type: String,
+            scope: &'a str,
+            expires_in: u64,
+            ext_expires_in: u64,
+            access_token: AccessToken,
+            refresh_token: AccessToken,
+        }
+
+        serde_json::from_str::<_RefreshTokenResponse>(&self).map(|rtr| RefreshTokenResponse {
+            token_type: rtr.token_type,
+            scopes: rtr.scope.split(' ').map(|s| s.to_owned()).collect(),
+            expires_in: rtr.expires_in,
+            ext_expires_in: rtr.ext_expires_in,
+            access_token: rtr.access_token,
+            refresh_token: rtr.refresh_token,
+        })
+    }
+}
+
+impl BearerToken for RefreshTokenResponse {
+    fn token_type(&self) -> &str {
+        &self.token_type
+    }
+    fn scopes(&self) -> &[String] {
+        &self.scopes
+    }
+    fn expires_in(&self) -> u64 {
+        self.expires_in
+    }
+    fn access_token(&self) -> &AccessToken {
+        &self.access_token
+    }
+}
+
+impl RefreshToken for RefreshTokenResponse {
+    fn refresh_token(&self) -> &AccessToken {
+        &self.refresh_token
+    }
+}
+
+impl ExtExpiresIn for RefreshTokenResponse {
+    fn ext_expires_in(&self) -> u64 {
+        self.ext_expires_in
+    }
+}

--- a/azure_sdk_auth_aad/src/traits.rs
+++ b/azure_sdk_auth_aad/src/traits.rs
@@ -1,0 +1,16 @@
+use oauth2::AccessToken;
+
+pub trait BearerToken {
+    fn token_type(&self) -> &str;
+    fn scopes(&self) -> &[String];
+    fn expires_in(&self) -> u64;
+    fn access_token(&self) -> &AccessToken;
+}
+
+pub trait RefreshToken {
+    fn refresh_token(&self) -> &AccessToken;
+}
+
+pub trait ExtExpiresIn {
+    fn ext_expires_in(&self) -> u64;
+}


### PR DESCRIPTION
This is a first implementation of the refresh token support. It has been tested successfully with the device code flow but it should support other flows as well.

This also shuffles the structs/types around a bit, in preparation for a more cohesive crate.

Fixes #290.