### PR TITLE
AAD credential providers and 'default' pattern

### DIFF
--- a/azure_sdk_auth_aad/Cargo.toml
+++ b/azure_sdk_auth_aad/Cargo.toml
@@ -33,6 +33,7 @@ async-trait          = "0.1.36"
 tokio                  = { version = "0.2", features = ["macros"] }
 azure_sdk_storage_core = { version = "0.44" }
 azure_sdk_storage_blob = { version = "0.44" }
+env_logger             = "0.7.1"
 
 [features]
 test_e2e             = []

--- a/azure_sdk_auth_aad/Cargo.toml
+++ b/azure_sdk_auth_aad/Cargo.toml
@@ -26,7 +26,8 @@ serde_json           = "1.0"
 log                  = "0.4"
 reqwest              = { version = "0.10", features = ["json"] }
 async-timer          = { version = "1.0.0-beta.3" }
-thiserror	     = "1.0"
+thiserror	           = "1.0"
+async-trait          = "0.1.36"
 
 [dev-dependencies]
 tokio                  = { version = "0.2", features = ["macros"] }

--- a/azure_sdk_auth_aad/Cargo.toml
+++ b/azure_sdk_auth_aad/Cargo.toml
@@ -26,7 +26,7 @@ serde_json           = "1.0"
 log                  = "0.4"
 reqwest              = { version = "0.10", features = ["json"] }
 async-timer          = { version = "1.0.0-beta.3" }
-thiserror	           = "1.0"
+thiserror            = "1.0"
 async-trait          = "0.1.36"
 
 [dev-dependencies]

--- a/azure_sdk_auth_aad/Cargo.toml
+++ b/azure_sdk_auth_aad/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name               = "azure_sdk_auth_aad"
-version            = "0.46.1"
+version            = "0.47.0"
 description        = "Rust wrappers around Microsoft Azure REST APIs - Azure OAuth2 helper crate"
 readme             = "README.md"
 authors            = ["Francesco Cogno <francesco.cogno@outlook.com>"]

--- a/azure_sdk_auth_aad/Cargo.toml
+++ b/azure_sdk_auth_aad/Cargo.toml
@@ -21,7 +21,7 @@ url                  = "2.1"
 futures              = "0.3"
 serde                = "1.0"
 serde_derive         = "1.0"
-chrono               = "0.4"
+chrono               = { version = "0.4", features = ["serde"] }
 serde_json           = "1.0"
 log                  = "0.4"
 reqwest              = { version = "0.10", features = ["json"] }

--- a/azure_sdk_auth_aad/examples/cli_credentials.rs
+++ b/azure_sdk_auth_aad/examples/cli_credentials.rs
@@ -1,0 +1,33 @@
+use azure_sdk_auth_aad::*;
+use std::error::Error;
+use url::Url;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let sub_id = std::env::var("AZURE_SUBSCRIPTION_ID")?;
+    let creds = AzureCliCredential {};
+    let res = creds
+        .get_token("https://management.azure.com/")
+        .await
+        .unwrap();
+    println!("Azure cli response == {:?}", res);
+    // Let's enumerate the Azure storage accounts
+    // in the subscription. Note: this way of calling the REST API
+    // will be different (and easier) using other Azure Rust SDK
+    // crates, this is just an example.
+    let url = Url::parse(&format!(
+                 "https://management.azure.com/subscriptions/{}/providers/Microsoft.Storage/storageAccounts?api-version=2019-06-01",
+                 sub_id
+             ))?;
+
+    let resp = reqwest::Client::new()
+        .get(url)
+        .header("Authorization", format!("Bearer {}", res.secret()))
+        .send()
+        .await?
+        .text()
+        .await?;
+
+    println!("\n\nresp {:?}", resp);
+    Ok(())
+}

--- a/azure_sdk_auth_aad/examples/cli_credentials.rs
+++ b/azure_sdk_auth_aad/examples/cli_credentials.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let resp = reqwest::Client::new()
         .get(url)
-        .header("Authorization", format!("Bearer {}", res.secret()))
+        .header("Authorization", format!("Bearer {}", res.token.secret()))
         .send()
         .await?
         .text()

--- a/azure_sdk_auth_aad/examples/default_credentials.rs
+++ b/azure_sdk_auth_aad/examples/default_credentials.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let resp = reqwest::Client::new()
         .get(url)
-        .header("Authorization", format!("Bearer {}", res.secret()))
+        .header("Authorization", format!("Bearer {}", res.token.secret()))
         .send()
         .await?
         .text()

--- a/azure_sdk_auth_aad/examples/default_credentials.rs
+++ b/azure_sdk_auth_aad/examples/default_credentials.rs
@@ -1,0 +1,35 @@
+use azure_sdk_auth_aad::*;
+use std::error::Error;
+use url::Url;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    env_logger::init();
+
+    let sub_id = std::env::var("AZURE_SUBSCRIPTION_ID")?;
+    let creds = DefaultCredential::default();
+    let res = creds
+        .get_token("https://management.azure.com/")
+        .await
+        .unwrap();
+    println!("Azure token response == {:?}", res);
+    // Let's enumerate the Azure storage accounts
+    // in the subscription. Note: this way of calling the REST API
+    // will be different (and easier) using other Azure Rust SDK
+    // crates, this is just an example.
+    let url = Url::parse(&format!(
+                 "https://management.azure.com/subscriptions/{}/providers/Microsoft.Storage/storageAccounts?api-version=2019-06-01",
+                 sub_id
+             ))?;
+
+    let resp = reqwest::Client::new()
+        .get(url)
+        .header("Authorization", format!("Bearer {}", res.secret()))
+        .send()
+        .await?
+        .text()
+        .await?;
+
+    println!("\n\nresp {:?}", resp);
+    Ok(())
+}

--- a/azure_sdk_auth_aad/examples/environment_credentials.rs
+++ b/azure_sdk_auth_aad/examples/environment_credentials.rs
@@ -1,0 +1,33 @@
+use azure_sdk_auth_aad::*;
+use std::error::Error;
+use url::Url;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let sub_id = std::env::var("AZURE_SUBSCRIPTION_ID")?;
+    let creds = EnvironmentCredential {};
+    let res = creds
+        .get_token("https://management.azure.com/")
+        .await
+        .unwrap();
+    println!("Azure cli response == {:?}", res);
+    // Let's enumerate the Azure storage accounts
+    // in the subscription. Note: this way of calling the REST API
+    // will be different (and easier) using other Azure Rust SDK
+    // crates, this is just an example.
+    let url = Url::parse(&format!(
+                 "https://management.azure.com/subscriptions/{}/providers/Microsoft.Storage/storageAccounts?api-version=2019-06-01",
+                 sub_id
+             ))?;
+
+    let resp = reqwest::Client::new()
+        .get(url)
+        .header("Authorization", format!("Bearer {}", res.secret()))
+        .send()
+        .await?
+        .text()
+        .await?;
+
+    println!("\n\nresp {:?}", resp);
+    Ok(())
+}

--- a/azure_sdk_auth_aad/examples/environment_credentials.rs
+++ b/azure_sdk_auth_aad/examples/environment_credentials.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let resp = reqwest::Client::new()
         .get(url)
-        .header("Authorization", format!("Bearer {}", res.secret()))
+        .header("Authorization", format!("Bearer {}", res.token.secret()))
         .send()
         .await?
         .text()

--- a/azure_sdk_auth_aad/src/lib.rs
+++ b/azure_sdk_auth_aad/src/lib.rs
@@ -30,6 +30,8 @@ use futures::TryFutureExt;
 mod responses;
 pub use naive_server::naive_server;
 mod prelude;
+mod token_credentials;
+pub use token_credentials::*;
 
 #[derive(Debug)]
 pub struct AuthObj {

--- a/azure_sdk_auth_aad/src/token_credentials/cli_credentials.rs
+++ b/azure_sdk_auth_aad/src/token_credentials/cli_credentials.rs
@@ -33,6 +33,7 @@ struct CliTokenResponse {
     pub token_type: String,
 }
 
+/// Enables authentication to Azure Active Directory using Azure CLI to obtain an access token.
 pub struct AzureCliCredential;
 
 #[async_trait::async_trait]

--- a/azure_sdk_auth_aad/src/token_credentials/cli_credentials.rs
+++ b/azure_sdk_auth_aad/src/token_credentials/cli_credentials.rs
@@ -1,0 +1,79 @@
+use crate::token_credentials::TokenCredential;
+use azure_sdk_core::errors::AzureError;
+use chrono::{DateTime, Utc};
+use oauth2::AccessToken;
+use std::io::ErrorKind;
+use std::process::Command;
+use std::str;
+
+mod az_cli_date_format {
+    use chrono::{DateTime, TimeZone, Utc};
+    use serde::{self, Deserialize, Deserializer};
+
+    const FORMAT: &'static str = "%Y-%m-%d %H:%M:%S.%6f";
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<DateTime<Utc>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Utc.datetime_from_str(&s, FORMAT)
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CliTokenResponse {
+    pub access_token: AccessToken,
+    #[serde(with = "az_cli_date_format")]
+    pub expires_on: DateTime<Utc>,
+    pub subscription: String,
+    pub tenant: String,
+    pub token_type: String,
+}
+
+pub struct AzureCliCredential;
+
+#[async_trait::async_trait]
+impl TokenCredential for AzureCliCredential {
+    async fn get_token(&self, resource: &str) -> Result<Box<AccessToken>, AzureError> {
+        let az_command = Command::new("az")
+            .args(&[
+                "account",
+                "get-access-token",
+                "--output",
+                "json",
+                "--resource",
+                resource,
+            ])
+            .output();
+
+        let res = match az_command {
+            Ok(az_output) => {
+                if az_output.status.success() {
+                    let output = str::from_utf8(&az_output.stdout).unwrap();
+                    let tr = serde_json::from_str::<CliTokenResponse>(output)
+                        .map(|tr| tr.access_token)
+                        .map_err(|_| {
+                            AzureError::GenericErrorWithText(
+                                "Failed to serialize response".to_string(),
+                            )
+                        })?;
+                    Ok(Box::new(tr))
+                } else {
+                    let output = str::from_utf8(&az_output.stderr).unwrap();
+                    Err(AzureError::GenericErrorWithText(output.to_string()))
+                }
+            }
+            Err(e) => match e.kind() {
+                ErrorKind::NotFound => Err(AzureError::GenericErrorWithText(
+                    "Azure CLI not installed".to_owned(),
+                )),
+                _ => Err(AzureError::GenericErrorWithText(e.to_string())),
+            },
+        };
+
+        res
+    }
+}

--- a/azure_sdk_auth_aad/src/token_credentials/client_secret_credentials.rs
+++ b/azure_sdk_auth_aad/src/token_credentials/client_secret_credentials.rs
@@ -1,0 +1,95 @@
+use crate::token_credentials::TokenCredential;
+
+use azure_sdk_core::errors::AzureError;
+use chrono::Utc;
+use oauth2::{
+    basic::BasicClient, reqwest::async_http_client, AccessToken,
+    AsyncClientCredentialsTokenRequest, AuthType, AuthUrl, Scope, TokenResponse, TokenUrl,
+};
+use std::{str, time::Duration};
+use url::Url;
+
+pub struct ClientSecretCredential {
+    tenant_id: String,
+    client_id: oauth2::ClientId,
+    client_secret: Option<oauth2::ClientSecret>,
+}
+
+impl ClientSecretCredential {
+    pub fn new(
+        tenant_id: String,
+        client_id: String,
+        client_secret: String,
+    ) -> ClientSecretCredential {
+        ClientSecretCredential {
+            tenant_id,
+            client_id: oauth2::ClientId::new(client_id),
+            client_secret: Some(oauth2::ClientSecret::new(client_secret)),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl TokenCredential for ClientSecretCredential {
+    async fn get_token(&self, resource: &str) -> Result<crate::TokenResponse, AzureError> {
+        let token_url = TokenUrl::from_url(
+            Url::parse(&format!(
+                "https://login.microsoftonline.com/{}/oauth2/v2.0/token",
+                self.tenant_id
+            ))
+            .map_err(|_| {
+                AzureError::GenericErrorWithText(format!(
+                    "Failed to construct token endpoint with tenant id {}",
+                    self.tenant_id,
+                ))
+            })?,
+        );
+
+        let auth_url = AuthUrl::from_url(
+            Url::parse(&format!(
+                "https://login.microsoftonline.com/{}/oauth2/v2.0/authorize",
+                self.tenant_id
+            ))
+            .map_err(|_| {
+                AzureError::GenericErrorWithText(format!(
+                    "Failed to construct authorize endpoint with tenant id {}",
+                    self.tenant_id,
+                ))
+            })?,
+        );
+
+        let client = BasicClient::new(
+            self.client_id.clone(),
+            self.client_secret.clone(),
+            auth_url,
+            Some(token_url),
+        )
+        .set_auth_type(AuthType::RequestBody);
+
+        let token_result = client
+            .exchange_client_credentials()
+            .add_scope(Scope::new(format!("{}.default", resource)))
+            .request_async(async_http_client)
+            .await
+            .map(|r| {
+                crate::TokenResponse::new(
+                    AccessToken::new(r.access_token().secret().to_owned()),
+                    Utc::now()
+                        + chrono::Duration::from_std(
+                            r.expires_in().unwrap_or(Duration::from_secs(0)),
+                        )
+                        .unwrap(),
+                )
+            })
+            .map_err(|e| match e {
+                oauth2::RequestTokenError::ServerResponse(s) => AzureError::GenericErrorWithText(
+                    s.error_description()
+                        .unwrap_or(&"Server error without description".to_string())
+                        .to_owned(),
+                ),
+                _ => AzureError::GenericErrorWithText("OAuth2 error".to_string()),
+            })?;
+
+        Ok(token_result)
+    }
+}

--- a/azure_sdk_auth_aad/src/token_credentials/client_secret_credentials.rs
+++ b/azure_sdk_auth_aad/src/token_credentials/client_secret_credentials.rs
@@ -9,6 +9,9 @@ use oauth2::{
 use std::{str, time::Duration};
 use url::Url;
 
+/// Enables authentication to Azure Active Directory using a client secret that was generated for an App Registration. More information on how
+/// to configure a client secret can be found here:
+/// https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-configure-app-access-web-apis#add-credentials-to-your-web-application
 pub struct ClientSecretCredential {
     tenant_id: String,
     client_id: oauth2::ClientId,

--- a/azure_sdk_auth_aad/src/token_credentials/default_credentials.rs
+++ b/azure_sdk_auth_aad/src/token_credentials/default_credentials.rs
@@ -1,0 +1,81 @@
+use crate::token_credentials::AzureCliCredential;
+use crate::{token_credentials::TokenCredential, EnvironmentCredential};
+use azure_sdk_core::errors::AzureError;
+use log::debug;
+use oauth2::AccessToken;
+
+pub struct DefaultCredentialBuilder {
+    include_environment_credential: bool,
+    include_cli_credential: bool,
+}
+
+impl DefaultCredentialBuilder {
+    pub fn new() -> Self {
+        DefaultCredentialBuilder {
+            include_cli_credential: true,
+            include_environment_credential: true,
+        }
+    }
+
+    pub fn exclude_environment_credential(&mut self) -> &mut Self {
+        self.include_environment_credential = false;
+        self
+    }
+    pub fn exclude_cli_credential(&mut self) -> &mut Self {
+        self.include_cli_credential = false;
+        self
+    }
+    pub fn build(&self) -> DefaultCredential {
+        let source_count: usize =
+            self.include_cli_credential as usize + self.include_cli_credential as usize;
+        let mut sources =
+            Vec::<Box<dyn TokenCredential + Send + Sync>>::with_capacity(source_count);
+        if self.include_environment_credential {
+            sources.push(Box::new(EnvironmentCredential {}));
+        }
+        if self.include_cli_credential {
+            sources.push(Box::new(AzureCliCredential {}));
+        }
+        DefaultCredential::with_sources(sources)
+    }
+}
+
+pub struct DefaultCredential {
+    sources: Vec<Box<dyn TokenCredential + Send + Sync>>,
+}
+
+impl DefaultCredential {
+    pub fn with_sources(sources: Vec<Box<dyn TokenCredential + Send + Sync>>) -> Self {
+        DefaultCredential { sources }
+    }
+}
+
+impl Default for DefaultCredential {
+    fn default() -> Self {
+        DefaultCredential {
+            sources: vec![
+                Box::new(EnvironmentCredential {}),
+                Box::new(AzureCliCredential {}),
+            ],
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl TokenCredential for DefaultCredential {
+    async fn get_token(&self, resource: &str) -> Result<Box<AccessToken>, AzureError> {
+        for source in &self.sources {
+            let token_res = source.get_token(resource).await;
+
+            if let Ok(token) = token_res {
+                return Ok(token);
+            } else {
+                debug!("Failed to get credentials: {:?}", token_res.err().unwrap());
+            }
+        }
+
+        Err(AzureError::GenericErrorWithText(
+            "End of default list".to_owned(),
+        ))
+    }
+}

--- a/azure_sdk_auth_aad/src/token_credentials/default_credentials.rs
+++ b/azure_sdk_auth_aad/src/token_credentials/default_credentials.rs
@@ -6,6 +6,7 @@ use crate::{
 use azure_sdk_core::errors::AzureError;
 use log::debug;
 
+/// Provides a mechanism of selectively disabling credentials used for a `DefaultCredential` instance
 pub struct DefaultCredentialBuilder {
     include_environment_credential: bool,
     include_managed_identity_credential: bool,
@@ -54,6 +55,12 @@ impl DefaultCredentialBuilder {
     }
 }
 
+/// Provides a default `TokenCredential` authentication flow for applications that will be deployed to Azure.  The following credential
+/// types if enabled will be tried, in order:
+/// - EnvironmentCredential
+/// - ManagedIdentityCredential
+/// - AzureCliCredential
+/// Consult the documentation of these credential types for more information on how they attempt authentication.
 pub struct DefaultCredential {
     sources: Vec<Box<dyn TokenCredential + Send + Sync>>,
 }

--- a/azure_sdk_auth_aad/src/token_credentials/default_credentials.rs
+++ b/azure_sdk_auth_aad/src/token_credentials/default_credentials.rs
@@ -1,8 +1,7 @@
 use crate::token_credentials::AzureCliCredential;
-use crate::{token_credentials::TokenCredential, EnvironmentCredential};
+use crate::{token_credentials::TokenCredential, EnvironmentCredential, TokenResponse};
 use azure_sdk_core::errors::AzureError;
 use log::debug;
-use oauth2::AccessToken;
 
 pub struct DefaultCredentialBuilder {
     include_environment_credential: bool,
@@ -63,7 +62,7 @@ impl Default for DefaultCredential {
 
 #[async_trait::async_trait]
 impl TokenCredential for DefaultCredential {
-    async fn get_token(&self, resource: &str) -> Result<Box<AccessToken>, AzureError> {
+    async fn get_token(&self, resource: &str) -> Result<TokenResponse, AzureError> {
         for source in &self.sources {
             let token_res = source.get_token(resource).await;
 

--- a/azure_sdk_auth_aad/src/token_credentials/environment_credentials.rs
+++ b/azure_sdk_auth_aad/src/token_credentials/environment_credentials.rs
@@ -1,0 +1,83 @@
+use crate::token_credentials::TokenCredential;
+
+use azure_sdk_core::errors::AzureError;
+use oauth2::{
+    basic::BasicClient, reqwest::async_http_client, AccessToken,
+    AsyncClientCredentialsTokenRequest, AuthType, AuthUrl, Scope, TokenResponse, TokenUrl,
+};
+use std::str;
+use url::Url;
+
+const AZURE_TENANT_ID_ENV_KEY: &str = "AZURE_TENANT_ID";
+const AZURE_CLIENT_ID_ENV_KEY: &str = "AZURE_CLIENT_ID";
+const AZURE_CLIENT_SECRET_ENV_KEY: &str = "AZURE_CLIENT_SECRET";
+
+pub struct EnvironmentCredential;
+
+#[async_trait::async_trait]
+impl TokenCredential for EnvironmentCredential {
+    async fn get_token(&self, resource: &str) -> Result<Box<AccessToken>, AzureError> {
+        let tenant_id = std::env::var(AZURE_TENANT_ID_ENV_KEY).map_err(|_| {
+            AzureError::GenericErrorWithText(format!(
+                "Missing tenant id set in {} environment variable",
+                AZURE_TENANT_ID_ENV_KEY
+            ))
+        })?;
+        let client_id = std::env::var(AZURE_CLIENT_ID_ENV_KEY)
+            .map(|client_id| oauth2::ClientId::new(client_id))
+            .map_err(|_| {
+                AzureError::GenericErrorWithText(format!(
+                    "Missing client id set in {} environment variable",
+                    AZURE_CLIENT_ID_ENV_KEY
+                ))
+            })?;
+        let client_secret = std::env::var(AZURE_CLIENT_SECRET_ENV_KEY)
+            .map(|client_secret| Some(oauth2::ClientSecret::new(client_secret)))
+            .unwrap_or_default();
+
+        let auth_url = AuthUrl::from_url(
+            Url::parse(&format!(
+                "https://login.microsoftonline.com/{}/oauth2/v2.0/authorize",
+                tenant_id
+            ))
+            .map_err(|_| {
+                AzureError::GenericErrorWithText(format!(
+                    "Failed to construct authorize endpoint with tenant id {}",
+                    tenant_id,
+                ))
+            })?,
+        );
+        let token_url = TokenUrl::from_url(
+            Url::parse(&format!(
+                "https://login.microsoftonline.com/{}/oauth2/v2.0/token",
+                tenant_id
+            ))
+            .map_err(|_| {
+                AzureError::GenericErrorWithText(format!(
+                    "Failed to construct token endpoint with tenant id {}",
+                    tenant_id,
+                ))
+            })?,
+        );
+
+        let client = BasicClient::new(client_id, client_secret, auth_url, Some(token_url))
+            .set_auth_type(AuthType::RequestBody);
+
+        let token_result = client
+            .exchange_client_credentials()
+            .add_scope(Scope::new(format!("{}.default", resource)))
+            .request_async(async_http_client)
+            .await
+            .map(|r| AccessToken::new(r.access_token().secret().to_string()))
+            .map_err(|e| match e {
+                oauth2::RequestTokenError::ServerResponse(s) => AzureError::GenericErrorWithText(
+                    s.error_description()
+                        .unwrap_or(&"Server error without description".to_string())
+                        .to_owned(),
+                ),
+                _ => AzureError::GenericErrorWithText("OAuth2 error".to_string()),
+            })?;
+
+        Ok(Box::new(token_result))
+    }
+}

--- a/azure_sdk_auth_aad/src/token_credentials/environment_credentials.rs
+++ b/azure_sdk_auth_aad/src/token_credentials/environment_credentials.rs
@@ -8,6 +8,18 @@ const AZURE_USERNAME_ENV_KEY: &str = "AZURE_USERNAME";
 const AZURE_PASSWORD_ENV_KEY: &str = "AZURE_PASSWORD";
 const AZURE_CLIENT_CERTIFICATE_PATH_ENV_KEY: &str = "AZURE_CLIENT_CERTIFICATE_PATH";
 
+/// Enables authentication to Azure Active Directory using client secret, or username and password,
+/// details configured in the following environment variables:
+///
+/// | Variable                            | Description                                      |
+/// |-------------------------------------|--------------------------------------------------|
+/// | `AZURE_TENANT_ID`                   | The Azure Active Directory tenant(directory) ID. |
+/// | `AZURE_CLIENT_ID`                   | The client(application) ID of an App Registration in the tenant. |
+/// | `AZURE_CLIENT_SECRET`               | A client secret that was generated for the App Registration. |
+///
+/// This credential ultimately uses a `ClientSecretCredential` to
+/// perform the authentication using these details. Please consult the
+/// documentation of that class for more details.
 pub struct EnvironmentCredential;
 
 #[async_trait::async_trait]

--- a/azure_sdk_auth_aad/src/token_credentials/managed_identity_credentials.rs
+++ b/azure_sdk_auth_aad/src/token_credentials/managed_identity_credentials.rs
@@ -18,7 +18,10 @@ const MSI_ENDPOINT_ENV_KEY: &str = "IDENTITY_ENDPOINT";
 const MSI_SECRET_ENV_KEY: &str = "IDENTITY_HEADER";
 const MSI_API_VERSION: &str = "2019-08-01";
 
-/// Built up from docs at https://docs.microsoft.com/en-us/azure/app-service/overview-managed-identity#using-the-rest-protocol
+/// Attempts authentication using a managed identity that has been assigned to the deployment environment. This authentication type works in Azure VMs,
+/// App Service and Azure Functions applications, as well as the Azure Cloud Shell
+///
+/// Built up from docs at [https://docs.microsoft.com/en-us/azure/app-service/overview-managed-identity#using-the-rest-protocol](https://docs.microsoft.com/en-us/azure/app-service/overview-managed-identity#using-the-rest-protocol)
 pub struct ManagedIdentityCredential;
 
 #[async_trait::async_trait]

--- a/azure_sdk_auth_aad/src/token_credentials/managed_identity_credentials.rs
+++ b/azure_sdk_auth_aad/src/token_credentials/managed_identity_credentials.rs
@@ -1,0 +1,59 @@
+use crate::token_credentials::TokenCredential;
+
+use azure_sdk_core::errors::AzureError;
+use chrono::{DateTime, Utc};
+use oauth2::AccessToken;
+use std::str;
+use url::Url;
+
+#[derive(Debug, Clone, Deserialize)]
+struct MsiTokenResponse {
+    pub access_token: AccessToken,
+    pub expires_on: DateTime<Utc>,
+    pub token_type: String,
+    pub resource: String,
+}
+
+const MSI_ENDPOINT_ENV_KEY: &str = "IDENTITY_ENDPOINT";
+const MSI_SECRET_ENV_KEY: &str = "IDENTITY_HEADER";
+const MSI_API_VERSION: &str = "2019-08-01";
+
+/// Built up from docs at https://docs.microsoft.com/en-us/azure/app-service/overview-managed-identity#using-the-rest-protocol
+pub struct ManagedIdentityCredential;
+
+#[async_trait::async_trait]
+impl TokenCredential for ManagedIdentityCredential {
+    async fn get_token(&self, resource: &str) -> Result<Box<AccessToken>, AzureError> {
+        let msi_endpoint = std::env::var(MSI_ENDPOINT_ENV_KEY)
+            .unwrap_or("http://169.254.169.254/metadata/identity/oauth2/token".to_owned());
+
+        let query_items = vec![("api-version", MSI_API_VERSION), ("resource", resource)];
+
+        let msi_endpoint_url = Url::parse_with_params(&msi_endpoint, &query_items)
+            .map_err(|error| AzureError::GenericErrorWithText(error.to_string()))?;
+
+        let msi_secret = std::env::var(MSI_SECRET_ENV_KEY).map_err(|_| {
+            AzureError::GenericErrorWithText(format!(
+                "Missing environment variable {}",
+                MSI_SECRET_ENV_KEY
+            ))
+        })?;
+
+        let client = reqwest::Client::new();
+        let res_body = client
+            .get(msi_endpoint_url)
+            .header("Metadata", "true")
+            .header("X-IDENTITY-HEADER", msi_secret)
+            .send()
+            .await
+            .map_err(|e| AzureError::GenericErrorWithText(e.to_string()))?
+            .text()
+            .await
+            .map_err(|e| AzureError::GenericErrorWithText(e.to_string()))?;
+
+        let token_response = serde_json::from_str::<MsiTokenResponse>(&res_body)
+            .map_err(|_| AzureError::GenericError)?;
+
+        Ok(Box::new(token_response.access_token))
+    }
+}

--- a/azure_sdk_auth_aad/src/token_credentials/mod.rs
+++ b/azure_sdk_auth_aad/src/token_credentials/mod.rs
@@ -12,9 +12,12 @@ use azure_sdk_core::errors::AzureError;
 use chrono::{DateTime, Utc};
 use oauth2::AccessToken;
 
+/// Represents an Azure service bearer access token with expiry information.
 #[derive(Debug, Clone)]
 pub struct TokenResponse {
+    /// Get the access token value.
     pub token: AccessToken,
+    /// Gets the time when the provided token expires.
     pub expires_on: DateTime<Utc>,
 }
 
@@ -23,8 +26,9 @@ impl TokenResponse {
         TokenResponse { token, expires_on }
     }
 }
-
+/// Represents a credential capable of providing an OAuth token.
 #[async_trait::async_trait]
 pub trait TokenCredential {
+    /// Gets a `TokenResponse` for the specified resource
     async fn get_token(&self, resource: &str) -> Result<TokenResponse, AzureError>;
 }

--- a/azure_sdk_auth_aad/src/token_credentials/mod.rs
+++ b/azure_sdk_auth_aad/src/token_credentials/mod.rs
@@ -1,9 +1,11 @@
 mod cli_credentials;
 mod default_credentials;
 mod environment_credentials;
+mod managed_identity_credentials;
 pub use crate::token_credentials::cli_credentials::*;
 pub use crate::token_credentials::default_credentials::*;
 pub use crate::token_credentials::environment_credentials::*;
+pub use crate::token_credentials::managed_identity_credentials::*;
 use azure_sdk_core::errors::AzureError;
 use oauth2::AccessToken;
 

--- a/azure_sdk_auth_aad/src/token_credentials/mod.rs
+++ b/azure_sdk_auth_aad/src/token_credentials/mod.rs
@@ -1,0 +1,9 @@
+mod environment_credentials;
+pub use crate::token_credentials::environment_credentials::*;
+use azure_sdk_core::errors::AzureError;
+use oauth2::AccessToken;
+
+#[async_trait::async_trait]
+pub trait TokenCredential {
+    async fn get_token(&self, resource: &str) -> Result<Box<AccessToken>, AzureError>;
+}

--- a/azure_sdk_auth_aad/src/token_credentials/mod.rs
+++ b/azure_sdk_auth_aad/src/token_credentials/mod.rs
@@ -1,6 +1,8 @@
 mod cli_credentials;
+mod default_credentials;
 mod environment_credentials;
 pub use crate::token_credentials::cli_credentials::*;
+pub use crate::token_credentials::default_credentials::*;
 pub use crate::token_credentials::environment_credentials::*;
 use azure_sdk_core::errors::AzureError;
 use oauth2::AccessToken;

--- a/azure_sdk_auth_aad/src/token_credentials/mod.rs
+++ b/azure_sdk_auth_aad/src/token_credentials/mod.rs
@@ -1,4 +1,6 @@
+mod cli_credentials;
 mod environment_credentials;
+pub use crate::token_credentials::cli_credentials::*;
 pub use crate::token_credentials::environment_credentials::*;
 use azure_sdk_core::errors::AzureError;
 use oauth2::AccessToken;

--- a/azure_sdk_auth_aad/src/token_credentials/mod.rs
+++ b/azure_sdk_auth_aad/src/token_credentials/mod.rs
@@ -7,9 +7,22 @@ pub use crate::token_credentials::default_credentials::*;
 pub use crate::token_credentials::environment_credentials::*;
 pub use crate::token_credentials::managed_identity_credentials::*;
 use azure_sdk_core::errors::AzureError;
+use chrono::{DateTime, Utc};
 use oauth2::AccessToken;
+
+#[derive(Debug, Clone)]
+pub struct TokenResponse {
+    pub token: AccessToken,
+    pub expires_on: DateTime<Utc>,
+}
+
+impl TokenResponse {
+    pub(crate) fn new(token: AccessToken, expires_on: DateTime<Utc>) -> Self {
+        TokenResponse { token, expires_on }
+    }
+}
 
 #[async_trait::async_trait]
 pub trait TokenCredential {
-    async fn get_token(&self, resource: &str) -> Result<Box<AccessToken>, AzureError>;
+    async fn get_token(&self, resource: &str) -> Result<TokenResponse, AzureError>;
 }

--- a/azure_sdk_auth_aad/src/token_credentials/mod.rs
+++ b/azure_sdk_auth_aad/src/token_credentials/mod.rs
@@ -1,8 +1,10 @@
 mod cli_credentials;
+mod client_secret_credentials;
 mod default_credentials;
 mod environment_credentials;
 mod managed_identity_credentials;
 pub use crate::token_credentials::cli_credentials::*;
+pub use crate::token_credentials::client_secret_credentials::*;
 pub use crate::token_credentials::default_credentials::*;
 pub use crate::token_credentials::environment_credentials::*;
 pub use crate::token_credentials::managed_identity_credentials::*;

--- a/azure_sdk_storage_blob/Cargo.toml
+++ b/azure_sdk_storage_blob/Cargo.toml
@@ -34,6 +34,7 @@ uuid                    = { version = "0.8", features = ["v4"] }
 [dev-dependencies]
 env_logger              = "0.7"
 tokio                   = { version = "0.2", features = ["macros"] }
+azure_sdk_auth_aad      = { path = "../azure_sdk_auth_aad" }
 
 [features]
 test_e2e                = []

--- a/azure_sdk_storage_blob/examples/blob_05_default_credential.rs
+++ b/azure_sdk_storage_blob/examples/blob_05_default_credential.rs
@@ -1,0 +1,45 @@
+#[macro_use]
+extern crate log;
+
+use azure_sdk_auth_aad::{DefaultCredential, TokenCredential};
+use azure_sdk_core::prelude::*;
+use azure_sdk_storage_blob::prelude::*;
+use azure_sdk_storage_core::prelude::*;
+use std::error::Error;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    env_logger::init();
+    // First we retrieve the account name, container and blob name from command line args
+
+    let account = std::env::args()
+        .nth(1)
+        .expect("please specify the account name as first command line parameter");
+    let container = std::env::args()
+        .nth(2)
+        .expect("please specify the container name as second command line parameter");
+    let blob = std::env::args()
+        .nth(3)
+        .expect("please specify the blob name as third command line parameter");
+
+    let bearer_token = DefaultCredential::default()
+        .get_token("https://storage.azure.com/")
+        .await?;
+
+    let client = client::with_bearer_token(account, bearer_token.secret());
+
+    trace!("Requesting blob");
+
+    let response = client
+        .get_blob()
+        .with_container_name(&container)
+        .with_blob_name(&blob)
+        .finalize()
+        .await?;
+
+    let s_content = String::from_utf8(response.data)?;
+    println!("blob == {:?}", blob);
+    println!("s_content == {}", s_content);
+
+    Ok(())
+}

--- a/azure_sdk_storage_blob/examples/blob_05_default_credential.rs
+++ b/azure_sdk_storage_blob/examples/blob_05_default_credential.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .get_token("https://storage.azure.com/")
         .await?;
 
-    let client = client::with_bearer_token(account, bearer_token.secret());
+    let client = client::with_bearer_token(account, bearer_token.token.secret());
 
     trace!("Requesting blob");
 


### PR DESCRIPTION
Following authentication patterns as other Azure SDK libraries as outlined in https://azure.github.io/azure-sdk/posts/2020-02-25/defaultazurecredentials.html and comparing implementations to python and .NET auth libraries

- Offers bearer token auth across a few mechanisms and outlines a path that applications planning to be deployed to Azure will use the `DefaultCredential` instance
- Have added a few examples with specific choices for use and an example in blob storage using the `DefaultCredential`
- The one I'm the least confident about is the `AzureCliCredential` implementation. I'm testing on macOS and if comparing to the [.NET implementation](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/identity/Azure.Identity/src/AzureCliCredential.cs) there is a lot more guards that could be added for other platforms and some assumptions about the cli installed location

Related to #300 