### PR TITLE
Workaround for Azurite Creation Dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [![Build Status](https://travis-ci.org/MindFlavor/AzureSDKForRust.svg?branch=master)](https://travis-ci.org/MindFlavor/AzureSDKForRust) [![Coverage Status](https://coveralls.io/repos/MindFlavor/AzureSDKForRust/badge.svg?branch=master&service=github)](https://coveralls.io/github/MindFlavor/AzureSDKForRust?branch=master) ![stability-unstable](https://img.shields.io/badge/stability-unstable-yellow.svg)
 
-[![tag](https://img.shields.io/github/tag/mindflavor/AzureSDKForRust.svg)](https://github.com/MindFlavor/AzureSDKForRust/tree/aad_0.47.0) [![release](https://img.shields.io/github/release/mindflavor/AzureSDKForRust.svg)](https://github.com/MindFlavor/AzureSDKForRust/releases/tag/aad_0.47.0) [![commitssince](https://img.shields.io/github/commits-since/mindflavor/AzureSDKForRust/aad_0.47.0)](https://github.com/MindFlavor/AzureSDKForRust/commits/master)
+[![tag](https://img.shields.io/github/tag/mindflavor/AzureSDKForRust.svg)](https://github.com/MindFlavor/AzureSDKForRust/tree/storage_blob_0.45.1) [![release](https://img.shields.io/github/release/mindflavor/AzureSDKForRust.svg)](https://github.com/MindFlavor/AzureSDKForRust/releases/tag/storage_blob_0.45.1) [![commitssince](https://img.shields.io/github/commits-since/mindflavor/AzureSDKForRust/storage_blob_0.45.1)](https://github.com/MindFlavor/AzureSDKForRust/commits/master)
 
 [![GitHub contributors](https://img.shields.io/github/contributors/MindFlavor/AzureSDKForRust.svg)](https://github.com/MindFlavor/AzureSDKForRust/graphs/contributors)
 

--- a/azure_sdk_core/Cargo.toml
+++ b/azure_sdk_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "azure_sdk_core"
-version       = "0.43.5"
+version       = "0.43.6"
 description   = "Rust wrappers around Microsoft Azure REST APIs - Core crate"
 readme        = "README.md"
 authors       = ["Francesco Cogno <francesco.cogno@outlook.com>", "Max Gortman <mgortman@microsoft.com>", "Dong Liu <doliu@microsoft.com>"]
@@ -39,3 +39,4 @@ env_logger              = "0.7"
 
 [features]
 test_e2e                = []
+azurite_workaround	= []

--- a/azure_sdk_core/src/parsing.rs
+++ b/azure_sdk_core/src/parsing.rs
@@ -39,10 +39,23 @@ impl FromStringOptional<chrono::DateTime<chrono::Utc>> for chrono::DateTime<chro
 }
 
 #[inline]
+#[cfg(not(feature = "azurite_workaround"))]
 pub fn from_azure_time(s: &str) -> Result<chrono::DateTime<chrono::Utc>, chrono::ParseError> {
     let dt = chrono::DateTime::parse_from_rfc2822(s)?;
     let dt_utc: chrono::DateTime<chrono::Utc> = dt.with_timezone(&chrono::Utc);
     Ok(dt_utc)
+}
+
+#[inline]
+#[cfg(feature = "azurite_workaround")]
+pub fn from_azure_time(s: &str) -> Result<chrono::DateTime<chrono::Utc>, chrono::ParseError> {
+    if let Ok(dt) = chrono::DateTime::parse_from_rfc2822(s) {
+        let dt_utc: chrono::DateTime<chrono::Utc> = dt.with_timezone(&chrono::Utc);
+        Ok(dt_utc)
+    } else {
+        log::warn!("Received an invalid date: {}, returning now()", s);
+        Ok(chrono::Utc::now())
+    }
 }
 
 #[inline]

--- a/azure_sdk_storage_blob/Cargo.toml
+++ b/azure_sdk_storage_blob/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "azure_sdk_storage_blob"
-version       = "0.45.0"
+version       = "0.45.1"
 description   = "Rust wrappers around Microsoft Azure REST APIs - Blob storage crate"
 readme        = "README.md"
 authors       = ["Francesco Cogno <francesco.cogno@outlook.com>", "Max Gortman <mgortman@microsoft.com>", "Dong Liu <doliu@microsoft.com>"]
@@ -15,7 +15,7 @@ categories    = ["api-bindings"]
 edition       = "2018"
 
 [dependencies]
-azure_sdk_core          = { path = "../azure_sdk_core", version = "0.43.5" }
+azure_sdk_core      	= { path = "../azure_sdk_core", version = "0.43.6", optional = true }
 azure_sdk_storage_core  = { path = "../azure_sdk_storage_core", version = "0.44.3" }
 md5                     = "0.7"
 RustyXML                = "0.3"
@@ -37,4 +37,6 @@ tokio                   = { version = "0.2", features = ["macros"] }
 azure_sdk_auth_aad      = { path = "../azure_sdk_auth_aad" }
 
 [features]
-test_e2e                = []
+default			= [ "azure_sdk_core" ]
+test_e2e                = [ "azure_sdk_core" ]
+azurite_workaround	= [ "azure_sdk_core/azurite_workaround" ]

--- a/azure_sdk_storage_blob/src/blob/mod.rs
+++ b/azure_sdk_storage_blob/src/blob/mod.rs
@@ -103,49 +103,14 @@ create_enum!(
 
 create_enum!(PageWriteType, (Update, "update"), (Clear, "clear"));
 
-#[cfg(not(feature = "azurite_workaround"))]
 #[derive(Debug, Clone, PartialEq)]
 pub struct Blob {
     pub name: String,
     pub container_name: String,
     pub snapshot_time: Option<DateTime<Utc>>,
+    #[cfg(not(feature = "azurite_workaround"))]
     pub creation_time: DateTime<Utc>,
-    pub last_modified: Option<DateTime<Utc>>, // optional because unavailable in uncommitted blobs
-    pub etag: Option<String>,                 // optional because unavailable in uncommitted blobs
-    pub content_length: u64,
-    pub content_type: Option<String>,
-    pub content_encoding: Option<String>,
-    pub content_language: Option<String>,
-    pub content_md5: Option<String>,
-    pub cache_control: Option<String>,
-    pub content_disposition: Option<String>,
-    pub x_ms_blob_sequence_number: Option<u64>,
-    pub blob_type: BlobType,
-    pub access_tier: Option<String>,
-    pub lease_status: Option<LeaseStatus>,
-    pub lease_state: LeaseState,
-    pub lease_duration: Option<LeaseDuration>,
-    pub copy_id: Option<String>,
-    pub copy_status: Option<CopyStatus>,
-    pub copy_source: Option<String>,
-    pub copy_progress: Option<Range>,
-    pub copy_completion_time: Option<DateTime<Utc>>,
-    pub copy_status_description: Option<String>,
-    pub incremental_copy: Option<bool>,
-    pub server_encrypted: bool,
-    pub access_tier_inferred: Option<bool>,
-    pub access_tier_change_time: Option<DateTime<Utc>>,
-    pub deleted_time: Option<DateTime<Utc>>,
-    pub remaining_retention_days: Option<u64>,
-    pub metadata: HashMap<String, String>,
-}
-
-#[cfg(feature = "azurite_workaround")]
-#[derive(Debug, Clone, PartialEq)]
-pub struct Blob {
-    pub name: String,
-    pub container_name: String,
-    pub snapshot_time: Option<DateTime<Utc>>,
+    #[cfg(feature = "azurite_workaround")]
     pub creation_time: Option<DateTime<Utc>>,
     pub last_modified: Option<DateTime<Utc>>, // optional because unavailable in uncommitted blobs
     pub etag: Option<String>,                 // optional because unavailable in uncommitted blobs


### PR DESCRIPTION
This is the same code as [PR 239](https://github.com/MindFlavor/AzureSDKForRust/pull/239) but it's behind a compilation flag: `azurite_workaround`. 
This way regular users won't have to use the weaker crate but Azurite users should be able to use it correctly now.