### PR TITLE
Support emulator connections with sas tokens

### DIFF
--- a/azure_sdk_storage_core/src/client.rs
+++ b/azure_sdk_storage_core/src/client.rs
@@ -172,6 +172,23 @@ pub fn from_connection_string(connection_string: &str) -> Result<KeyClient, Azur
             ConnectionString {
                 account_name: Some(account),
                 sas: Some(sas_token),
+                use_development_storage: Some(true),
+                blob_endpoint: Some(blob_endpoint_url),
+                table_endpoint: Some(table_endpoint_url),
+                ..
+            } => {
+                Ok(KeyClient::new(
+                    account.to_owned(),
+                    String::new(),
+                    Some(get_sas_token_parms(sas_token)),
+                    client,
+                    blob_endpoint_url.to_owned(),
+                    table_endpoint_url.to_owned(),
+                ))
+            }
+            ConnectionString {
+                account_name: Some(account),
+                sas: Some(sas_token),
                 ..
             } => Ok(KeyClient ::new(
                 account.to_owned(),

--- a/azure_sdk_storage_core/src/connection_string.rs
+++ b/azure_sdk_storage_core/src/connection_string.rs
@@ -157,7 +157,7 @@ impl<'a> ConnectionString<'a> {
             .filter(|s| !s.chars().all(char::is_whitespace));
 
         for kv_pair_str in kv_str_pairs {
-            let mut kv = kv_pair_str.trim().split('=');
+            let mut kv = kv_pair_str.trim().splitn(2, '=');
             let k = match kv.next() {
                 Some(k) if k.chars().all(char::is_whitespace) => {
                     return Err(ConnectionStringError::ParsingError {


### PR DESCRIPTION
Creating a draft request to address #310. This modifies `Client::from_connection_string` function to create development storage clients access with SAS tokens. 

Example usage:
```
fn abs_emulator_client_sas(sas_token: &str) -> Result<KeyClient,AzureError> {
    let connection_string = format!("DefaultEndpointsProtocol=http; \
                                     AccountName=devstoreaccount1; \
                                     BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1; \
                                     TableEndpoint=http://127.0.0.1:10002/devstoreaccount1; \
                                     UseDevelopmentStorage=true; \
                                     SharedAccessSignature=?{};",
                                     sas_token);
    return Client::from_connection_string(&connection_string)
}
```

This code is tested against Azurite. The SAS token client is able to list objects if it is correctly generated. Have to prefix SAS token with `?` in connection_string for now as it is parsed with `url::Url::query_pairs` in `get_sas_token_parms`